### PR TITLE
chore: bump up package Microsoft.Extentions.* to 3.1.5

### DIFF
--- a/src/ConsoleAppFramework.WebHosting/ConsoleAppFramework.WebHosting.csproj
+++ b/src/ConsoleAppFramework.WebHosting/ConsoleAppFramework.WebHosting.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="4.7.0" />
+        <PackageReference Include="System.Text.Json" Version="4.7.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ConsoleAppFramework/ConsoleAppFramework.csproj
+++ b/src/ConsoleAppFramework/ConsoleAppFramework.csproj
@@ -19,9 +19,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
-        <PackageReference Include="System.Text.Json" Version="4.7.0" />
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
+        <PackageReference Include="System.Text.Json" Version="4.7.2" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/ConsoleAppFramework.Tests/ConsoleAppFramework.Tests.csproj
+++ b/tests/ConsoleAppFramework.Tests/ConsoleAppFramework.Tests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" version="4.5.3" />
-      <PackageReference Include="System.Text.Json" Version="4.7.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" version="4.5.4" />
+      <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## TL;DR

Microsoft.Extentions.* 3.1.0 has issue when `dotnet pack`.

> Error Message: "The DateTimeOffset specified cannot be converted into a Zip file timestamp"

This PR bump up Microsoft.Extentions.* to 3.1.5 and also it's dependencies.

## REF

https://github.com/NuGet/Home/issues/7001