### PR TITLE
Omit value type legend from boolean option

### DIFF
--- a/src/ConsoleAppFramework/CommandHelpBuilder.cs
+++ b/src/ConsoleAppFramework/CommandHelpBuilder.cs
@@ -154,7 +154,7 @@ namespace ConsoleAppFramework
         {
             var argumentsFormatted = definition.Options
                 .Where(x => x.Index.HasValue)
-                .Select(x => (Argument: $"[{x.Index}] {x.FormattedValueTypeName}", x.Description, x.IsRequired, x.DefaultValue))
+                .Select(x => (Argument: $"[{x.Index}] {x.FormattedValueTypeName}", x.Description))
                 .ToArray();
 
             if (!argumentsFormatted.Any()) return string.Empty;
@@ -398,14 +398,14 @@ namespace ConsoleAppFramework
             public string[] Options { get; }
             public string Description { get; }
             public string? DefaultValue { get; }
-            public string? ValueTypeName { get; }
+            public string ValueTypeName { get; }
             public int? Index { get; }
 
             public bool IsRequired => DefaultValue == null;
             public bool IsFlag { get; }
-            public string FormattedValueTypeName => (ValueTypeName == null) ? "" : "<" + ValueTypeName + ">";
+            public string FormattedValueTypeName => "<" + ValueTypeName + ">";
 
-            public CommandOptionHelpDefinition(string[] options, string description, string? valueTypeName, string? defaultValue, int? index, bool isFlag)
+            public CommandOptionHelpDefinition(string[] options, string description, string valueTypeName, string? defaultValue, int? index, bool isFlag)
             {
                 Options = options;
                 Description = description;

--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -323,6 +323,11 @@ namespace ConsoleAppFramework
                 {
                     invokeArgs[i] = item.DefaultValue;
                 }
+                else if (item.ParameterType == typeof(bool))
+				{
+                    // bool without default value should be considered that it has implicit default value of false.
+                    invokeArgs[i] = false;
+				}
                 else
                 {
                     var name = item.Name;

--- a/tests/ConsoleAppFramework.Tests/CommandHelpTest.cs
+++ b/tests/ConsoleAppFramework.Tests/CommandHelpTest.cs
@@ -175,6 +175,48 @@ Options:
             builder.BuildOptionsMessage(def).Should().Be(expected);
         }
 
+        [Fact]
+        public void CreateCommandHelp_BooleanWithoutDefault_ShownWithoutValue()
+        {
+            var builder = CreateCommandHelpBuilder();
+            var def = builder.CreateCommandHelpDefinition(typeof(CommandHelpTestBatch).GetMethod(nameof(CommandHelpTestBatch.OptionBooleanSwitchWithoutDefault)));
+            var expected = @"
+Options:
+  -f, -flag    desc (Optional)
+
+".TrimStart();
+
+            builder.BuildOptionsMessage(def).Should().Be(expected);
+        }
+
+        [Fact]
+        public void CreateCommandHelp_BooleanWithTrueDefault_ShownWithValue()
+        {
+            var builder = CreateCommandHelpBuilder();
+            var def = builder.CreateCommandHelpDefinition(typeof(CommandHelpTestBatch).GetMethod(nameof(CommandHelpTestBatch.OptionBooleanSwitchWithTrueDefault)));
+            var expected = @"
+Options:
+  -f, -flag <Boolean>    desc (Default: True)
+
+".TrimStart();
+
+            builder.BuildOptionsMessage(def).Should().Be(expected);
+        }
+
+        [Fact]
+        public void CreateCommandHelp_BooleanWithTrueDefault_ShownWithoutValue()
+        {
+            var builder = CreateCommandHelpBuilder();
+            var def = builder.CreateCommandHelpDefinition(typeof(CommandHelpTestBatch).GetMethod(nameof(CommandHelpTestBatch.OptionBooleanSwitchWithFalseDefault)));
+            var expected = @"
+Options:
+  -f, -flag    desc (Optional)
+
+".TrimStart();
+
+            builder.BuildOptionsMessage(def).Should().Be(expected);
+        }
+
         //[Fact]
         //public void CreateCommandHelpDefinition()
         //{
@@ -355,6 +397,18 @@ Options:
         }
 
         public void OptionIndex([Option(2, "3rd")]int arg0, [Option(1, "2nd")]string arg1, [Option(0, "1st")]bool arg2)
+        {
+        }
+
+        public void OptionBooleanSwitchWithoutDefault([Option("f", "desc")]bool flag)
+        {
+        }
+
+        public void OptionBooleanSwitchWithTrueDefault([Option("f", "desc")] bool flag = true)
+        {
+        }
+
+        public void OptionBooleanSwitchWithFalseDefault([Option("f", "desc")] bool flag = false)
         {
         }
 

--- a/tests/ConsoleAppFramework.Tests/SingleContainedTest.cs
+++ b/tests/ConsoleAppFramework.Tests/SingleContainedTest.cs
@@ -204,9 +204,10 @@ namespace ConsoleAppFramework.Tests
 
         public class BooleanSwitch : ConsoleAppBase
         {
-            public void Hello(string x, bool foo = false, bool yeah = false)
+            public void Hello(string x, bool bar, bool foo = false, bool yeah = false)
             {
                 Context.Logger.LogInformation($"x:{x}");
+                Context.Logger.LogInformation($"bar:{bar}");
                 Context.Logger.LogInformation($"foo:{foo}");
                 Context.Logger.LogInformation($"yeah:{yeah}");
             }
@@ -217,23 +218,36 @@ namespace ConsoleAppFramework.Tests
         {
             {
                 var log = new LogStack();
+                var args = "-x foo -bar -foo -yeah".Split(' ');
+                await new HostBuilder()
+                    .ConfigureTestLogging(testOutput, log, true)
+                    .RunConsoleAppFrameworkAsync<BooleanSwitch>(args);
+                log.InfoLogShouldBe(0, "x:foo");
+                log.InfoLogShouldBe(1, "bar:True");
+                log.InfoLogShouldBe(2, "foo:True");
+                log.InfoLogShouldBe(3, "yeah:True");
+            }
+            {
+                var log = new LogStack();
+                var args = "-x foo -bar -foo".Split(' ');
+                await new HostBuilder()
+                    .ConfigureTestLogging(testOutput, log, true)
+                    .RunConsoleAppFrameworkAsync<BooleanSwitch>(args);
+                log.InfoLogShouldBe(0, "x:foo");
+                log.InfoLogShouldBe(1, "bar:True");
+                log.InfoLogShouldBe(2, "foo:True");
+                log.InfoLogShouldBe(3, "yeah:False");
+            }
+            {
+                var log = new LogStack();
                 var args = "-x foo -foo -yeah".Split(' ');
                 await new HostBuilder()
                     .ConfigureTestLogging(testOutput, log, true)
                     .RunConsoleAppFrameworkAsync<BooleanSwitch>(args);
                 log.InfoLogShouldBe(0, "x:foo");
-                log.InfoLogShouldBe(1, "foo:True");
-                log.InfoLogShouldBe(2, "yeah:True");
-            }
-            {
-                var log = new LogStack();
-                var args = "-x foo -foo".Split(' ');
-                await new HostBuilder()
-                    .ConfigureTestLogging(testOutput, log, true)
-                    .RunConsoleAppFrameworkAsync<BooleanSwitch>(args);
-                log.InfoLogShouldBe(0, "x:foo");
-                log.InfoLogShouldBe(1, "foo:True");
-                log.InfoLogShouldBe(2, "yeah:False");
+                log.InfoLogShouldBe(1, "bar:False");
+                log.InfoLogShouldBe(2, "foo:True");
+                log.InfoLogShouldBe(3, "yeah:True");
             }
         }
     }


### PR DESCRIPTION
Fixes #52.

This PR also includes:

* Fix indentation logic which did not assume lack of value type legend.
* Some refactoring which resolves maintenanceability issues found by this PR work.