### PR TITLE
Hotfix displayhelpcommand

### DIFF
--- a/src/ConsoleAppFramework/CommandHelpBuilder.cs
+++ b/src/ConsoleAppFramework/CommandHelpBuilder.cs
@@ -361,7 +361,7 @@ namespace ConsoleAppFramework
             }
 
             return new CommandHelpDefinition(
-                $"{method.DeclaringType!.Name.ToLower()}",
+                method.DeclaringType.GetCustomAttribute<CommandAttribute>()?.CommandNames?.FirstOrDefault() ?? method.DeclaringType!.Name.ToLower(),
                 command?.CommandNames ?? new[] { method.Name.ToLower() },
                 parameterDefinitions.OrderBy(x => x.Index ?? int.MaxValue).ToArray(),
                 command?.Description ?? String.Empty

--- a/tests/ConsoleAppFramework.Tests/CommandHelpTest.cs
+++ b/tests/ConsoleAppFramework.Tests/CommandHelpTest.cs
@@ -19,9 +19,9 @@ namespace ConsoleAppFramework.Tests
             var builder = CreateCommandHelpBuilder();
             var expected = @$"
 Commands:
-  commandhelptestlistmessagebatch hello                            
-  commandhelptestlistmessagebatch YetAnotherHello                  
-  commandhelptestlistmessagebatch HelloWithAliasWithDescription    Description of command
+  list-message-batch hello                            
+  list-message-batch YetAnotherHello                  
+  list-message-batch HelloWithAliasWithDescription    Description of command
 ".TrimStart();
 
             var msg = builder.BuildMethodListMessage(new[] { typeof(CommandHelpTestListMessageBatch) }, out _);
@@ -36,9 +36,9 @@ Commands:
             var expected = @"Usage: Nantoka <Command>
 
 Commands:
-  commandhelptestlistmessagebatch hello                            
-  commandhelptestlistmessagebatch YetAnotherHello                  
-  commandhelptestlistmessagebatch HelloWithAliasWithDescription    Description of command
+  list-message-batch hello                            
+  list-message-batch YetAnotherHello                  
+  list-message-batch HelloWithAliasWithDescription    Description of command
 ";
 
             builder.BuildHelpMessage(new[] { typeof(CommandHelpTestListMessageBatch) }).Should().Be(expected);
@@ -342,6 +342,7 @@ Options:
         //}
     }
 
+    [Command("list-message-batch")]
     public class CommandHelpTestListMessageBatch : ConsoleAppBase
     {
         public void Hello()


### PR DESCRIPTION
correct display of command class name help text