### PR TITLE
Attaching filter via attribute leads to InvalidOperationException

### DIFF
--- a/src/ConsoleAppFramework/ConsoleAppFilter.cs
+++ b/src/ConsoleAppFramework/ConsoleAppFilter.cs
@@ -75,12 +75,9 @@ namespace ConsoleAppFramework
             var methodFilters = methodInfo.GetCustomAttributes<ConsoleAppFilterAttribute>(true);
             foreach (var item in classFilters.Concat(methodFilters))
             {
-                var filter = ActivatorUtilities.CreateInstance<ConsoleAppFilter>(serviceProvider, item.Type);
-                if (filter != null)
-                {
-                    filter.Order = item.Order;
-                    list.Add(filter);
-                }
+                var filter = (ConsoleAppFilter) ActivatorUtilities.CreateInstance(serviceProvider, item.Type);
+                filter.Order = item.Order;
+                list.Add(filter);
             }
 
             var sortedAndReversedFilters = list.OrderBy(x => x.Order).Reverse().ToArray();

--- a/tests/ConsoleAppFramework.Tests/Integration/CommandFilterTest.cs
+++ b/tests/ConsoleAppFramework.Tests/Integration/CommandFilterTest.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+// ReSharper disable UnusedMember.Local
+// ReSharper disable ClassNeverInstantiated.Local
+
+namespace ConsoleAppFramework.Integration.Test;
+
+public class FilterTest
+{
+	[Fact]
+	public void ApplyAttributeFilterTest()
+	{
+		using var console = new CaptureConsoleOutput();
+		var args = new[] { "test-argument-name" };
+		Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<TestConsoleApp>(args);
+		console.Output.Should().Contain("[in filter] before");
+		console.Output.Should().Contain(args[0]);
+		console.Output.Should().Contain("[in filter] after");
+	}
+
+	/// <inheritdoc />
+	private class TestConsoleApp : ConsoleAppBase
+	{
+		[RootCommand]
+		[ConsoleAppFilter(typeof(TestFilter))]
+		public void RootCommand([Option(index: 0)]string someArgument) => Console.WriteLine(someArgument);
+	}
+
+	/// <inheritdoc />
+	private class TestFilter : ConsoleAppFilter
+	{
+		/// <inheritdoc />
+		public override async ValueTask Invoke(ConsoleAppContext context, Func<ConsoleAppContext, ValueTask> next)
+		{
+			Console.WriteLine("[in filter] before");
+			await next(context);
+			Console.WriteLine("[in filter] after");
+		}
+	}
+}


### PR DESCRIPTION
When `ConsoleAppFilter`-derived filter is applied via attribute, application crashes with following error:

    System.InvalidOperationException: A suitable constructor for type 'ConsoleAppFramework.ConsoleAppFilter' could not be located. Ensure the type is concrete and all parameters of a public constructor are either registered as services or passed as arguments. Also ensure no extraneous arguments are provided.
       at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance(IServiceProvider provider, Type instanceType, Object[] parameters)
       at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance[T](IServiceProvider provider, Object[] parameters)
       at ConsoleAppFramework.WithFilterInvoker.InvokeAsync() in /Users/zadykian/Repository/personal/ConsoleAppFramework/src/ConsoleAppFramework/ConsoleAppFilter.cs:line 79
       at ConsoleAppFramework.ConsoleAppEngine.RunCore(Type type, MethodInfo methodInfo, Object instance, String[] args, Int32 argsOffset) in /Users/zadykian/Repository/personal/ConsoleAppFramework/src/ConsoleAppFramework/ConsoleAppEngine.cs:line 191
       at ConsoleAppFramework.ConsoleAppEngine.RunCore(Type type, MethodInfo methodInfo, Object instance, String[] args, Int32 argsOffset) in /Users/zadykian/Repository/personal/ConsoleAppFramework/src/ConsoleAppFramework/ConsoleAppEngine.cs:line 207

Error is caused by incorrect `ActivatorUtilities.CreateInstance` call inside `WithFilterInvoker.InvokeAsync`. When `ConsoleAppFilter` is passed as generic parameter, `ActivatorUtilities` tries to create `ConsoleAppFilter` instance, which is an abstract type.

To create application filter instance correctly, non-generic overload of `CreateInstance` should be used.
Fixes #74