### PR TITLE
Parameters validation via attributes

### DIFF
--- a/src/ConsoleAppFramework/ConsoleAppBuilder.cs
+++ b/src/ConsoleAppFramework/ConsoleAppBuilder.cs
@@ -41,6 +41,7 @@ namespace ConsoleAppFramework
                     configureOptions?.Invoke(ctx, options);
                     options.CommandLineArguments = args;
                     services.AddSingleton(options);
+                    services.AddSingleton<IParamsValidator, ParamsValidator>();
 
                     if (options.ReplaceToUseSimpleConsoleLogger)
                     {

--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -2,7 +2,9 @@
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
@@ -18,13 +20,20 @@ namespace ConsoleAppFramework
         readonly CancellationToken cancellationToken;
         readonly ConsoleAppOptions options;
         readonly IServiceProviderIsService isService;
+        readonly IParamsValidator paramsValidator;
         readonly bool isStrict;
 
-        public ConsoleAppEngine(ILogger<ConsoleApp> logger, IServiceProvider provider, ConsoleAppOptions options, IServiceProviderIsService isService, CancellationToken cancellationToken)
+        public ConsoleAppEngine(ILogger<ConsoleApp> logger,
+            IServiceProvider provider,
+            ConsoleAppOptions options,
+            IServiceProviderIsService isService,
+            IParamsValidator paramsValidator,
+            CancellationToken cancellationToken)
         {
             this.logger = logger;
             this.provider = provider;
             this.cancellationToken = cancellationToken;
+            this.paramsValidator = paramsValidator;
             this.options = options;
             this.isService = isService;
             this.isStrict = options.StrictOption;
@@ -166,6 +175,13 @@ namespace ConsoleAppFramework
                     }
                 }
                 invokeArgs = newInvokeArgs;
+            }
+
+            var validationResult = paramsValidator.ValidateParameters(originalParameters.Zip(invokeArgs));
+            if (validationResult != ValidationResult.Success)
+            {
+                await SetFailAsync(validationResult!.ErrorMessage!);
+                return;
             }
 
             try

--- a/src/ConsoleAppFramework/ParamsValidator.cs
+++ b/src/ConsoleAppFramework/ParamsValidator.cs
@@ -16,8 +16,7 @@ namespace ConsoleAppFramework
 		/// Validate <paramref name="parameters"/> of command based on validation attributes
 		/// applied to method's parameters.
 		/// </summary>
-		public ValidationResult? ValidateParameters(
-			IEnumerable<(ParameterInfo Parameter, object? Value)> parameters);
+		ValidationResult? ValidateParameters(IEnumerable<(ParameterInfo Parameter, object? Value)> parameters);
 	}
 
 	/// <inheritdoc />
@@ -58,7 +57,7 @@ namespace ConsoleAppFramework
 				.ToImmutableArray();
 
 			return failedResults.Any()
-				? new ValidationResult(string.Concat(';', failedResults.Select(res => res?.ErrorMessage)))
+				? new ValidationResult(string.Concat("; ", failedResults.Select(res => res?.ErrorMessage)))
 				: ValidationResult.Success;
 		}
 

--- a/src/ConsoleAppFramework/ParamsValidator.cs
+++ b/src/ConsoleAppFramework/ParamsValidator.cs
@@ -36,7 +36,6 @@ namespace ConsoleAppFramework
 				return ValidationResult.Success;
 			}
 
-			// todo: parameter may have overridden name via OptionAttribute
 			var errorMessage = string.Join(Environment.NewLine,
 				invalidParameters
 					.Select(tuple => $"{tuple.Parameter.Name!.ToLower()} ({tuple.Value}): {tuple.Result!.ErrorMessage}")

--- a/src/ConsoleAppFramework/ParamsValidator.cs
+++ b/src/ConsoleAppFramework/ParamsValidator.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+
+namespace ConsoleAppFramework
+{
+	/// <summary>
+	/// Validator of command parameters.
+	/// </summary>
+	public interface IParamsValidator
+	{
+		/// <summary>
+		/// Validate <paramref name="parameters"/> of command based on validation attributes
+		/// applied to method's parameters.
+		/// </summary>
+		public ValidationResult? ValidateParameters(
+			IEnumerable<(ParameterInfo Parameter, object? Value)> parameters);
+	}
+
+	/// <inheritdoc />
+	public class ParamsValidator : IParamsValidator
+	{
+		/// <inheritdoc />
+		ValidationResult? IParamsValidator.ValidateParameters(
+			IEnumerable<(ParameterInfo Parameter, object? Value)> parameters)
+		{
+			var res = parameters
+				.Select(tuple => Validate(tuple.Parameter, tuple.Value))
+				.Wh
+		}
+
+		private static ValidationResult? Validate(ParameterInfo parameterInfo, object? value)
+		{
+			if (value is null) return ValidationResult.Success;
+
+			var validationContext = new ValidationContext(value, null, null);
+
+			var failedResults = GetValidationAttributes(parameterInfo)
+				.Select(attribute => attribute.GetValidationResult(value, validationContext))
+				.Where(result => result != ValidationResult.Success)
+				.ToImmutableArray();
+
+			return failedResults.Any()
+				? new ValidationResult(string.Concat(';', failedResults.Select(res => res?.ErrorMessage)))
+				: ValidationResult.Success;
+		}
+
+		private static IEnumerable<ValidationAttribute> GetValidationAttributes(ParameterInfo parameterInfo)
+			=> parameterInfo
+				.GetCustomAttributes()
+				.OfType<ValidationAttribute>();
+	}
+}

--- a/src/ConsoleAppFramework/ParamsValidator.cs
+++ b/src/ConsoleAppFramework/ParamsValidator.cs
@@ -57,7 +57,7 @@ namespace ConsoleAppFramework
 				.ToImmutableArray();
 
 			return failedResults.Any()
-				? new ValidationResult(string.Concat("; ", failedResults.Select(res => res?.ErrorMessage)))
+				? new ValidationResult(string.Join("; ", failedResults.Select(res => res?.ErrorMessage)))
 				: ValidationResult.Success;
 		}
 

--- a/src/ConsoleAppFramework/ParamsValidator.cs
+++ b/src/ConsoleAppFramework/ParamsValidator.cs
@@ -22,6 +22,10 @@ namespace ConsoleAppFramework
 	/// <inheritdoc />
 	public class ParamsValidator : IParamsValidator
 	{
+		private readonly ConsoleAppOptions options;
+
+		public ParamsValidator(ConsoleAppOptions options) => this.options = options;
+
 		/// <inheritdoc />
 		ValidationResult? IParamsValidator.ValidateParameters(
 			IEnumerable<(ParameterInfo Parameter, object? Value)> parameters)
@@ -38,10 +42,13 @@ namespace ConsoleAppFramework
 
 			var errorMessage = string.Join(Environment.NewLine,
 				invalidParameters
-					.Select(tuple => $"{tuple.Parameter.Name!.ToLower()} ({tuple.Value}): {tuple.Result!.ErrorMessage}")
+					.Select(tuple => 
+						$"{options.NameConverter(tuple.Parameter.Name!)} " +
+						$"({tuple.Value}): " +
+						$"{tuple.Result!.ErrorMessage}")
 			);
 
-			return new ValidationResult($"Some parameters have invalid value:{Environment.NewLine}{errorMessage}");
+			return new ValidationResult($"Some parameters have invalid values:{Environment.NewLine}{errorMessage}");
 		}
 
 		private static ValidationResult? Validate(ParameterInfo parameterInfo, object? value)

--- a/tests/ConsoleAppFramework.Tests/Integration/ValidationAttributeTests.cs
+++ b/tests/ConsoleAppFramework.Tests/Integration/ValidationAttributeTests.cs
@@ -1,8 +1,8 @@
 using System;
 using System.ComponentModel.DataAnnotations;
 using FluentAssertions;
-using Microsoft.Extensions.Hosting;
 using Xunit;
+
 // ReSharper disable UnusedMember.Global
 // ReSharper disable UnusedParameter.Global
 
@@ -22,20 +22,44 @@ public class ValidationAttributeTests
 		const string optionValue = "too-large-string-value";
 
 		var args = new[] { nameof(AppWithValidationAttributes.StrLength), $"--{optionName}", optionValue };
-		Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<AppWithValidationAttributes>(args);
+		ConsoleApp.Run<AppWithValidationAttributes>(args);
 
-		// Validation fails, so StrLength command is not executed.
-		console.Output.Should().NotContain(AppWithValidationAttributes.StrLengthOutput);
+		// Validation should fail, so StrLength command should not be executed.
+		console.Output.Should().NotContain(AppWithValidationAttributes.Output);
 
 		console.Output.Should().Contain(optionName);
 		console.Output.Should().Contain(optionValue);
 	}
 
+	[Fact]
+	public void Command_With_Multiple_Params()
+	{
+		using var console = new CaptureConsoleOutput();
+
+		var args = new[]
+		{
+			nameof(AppWithValidationAttributes.MultipleParams),
+			"--second-arg", "10",
+			"--first-arg", "invalid-email-address"
+		};
+
+		ConsoleApp.Run<AppWithValidationAttributes>(args);
+
+		// Validation should fail, so StrLength command should not be executed.
+		console.Output.Should().NotContain(AppWithValidationAttributes.Output);
+	}
+
 	/// <inheritdoc />
 	internal class AppWithValidationAttributes : ConsoleAppBase
 	{
-		public const string StrLengthOutput = $"hello from {nameof(StrLength)}";
+		public const string Output = $"hello from {nameof(AppWithValidationAttributes)}";
 
-		public void StrLength([StringLength(maximumLength: 8)] string arg) => Console.WriteLine(StrLengthOutput);
+		[Command(nameof(StrLength))]
+		public void StrLength([StringLength(maximumLength: 8)] string arg) => Console.WriteLine(Output);
+
+		[Command(nameof(MultipleParams))]
+		public void MultipleParams(
+			[EmailAddress] string firstArg,
+			[Range(0, 2)]  int secondArg) => Console.WriteLine(Output);
 	}
 }

--- a/tests/ConsoleAppFramework.Tests/Integration/ValidationAttributeTests.cs
+++ b/tests/ConsoleAppFramework.Tests/Integration/ValidationAttributeTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+// ReSharper disable UnusedMember.Global
+// ReSharper disable UnusedParameter.Global
+
+namespace ConsoleAppFramework.Integration.Test;
+
+public class ValidationAttributeTests
+{
+	/// <summary>
+	/// Try to execute command with invalid option value.
+	/// </summary>
+	[Fact]
+	public void Validate_String_Length_Test()
+	{
+		using var console = new CaptureConsoleOutput();
+
+		const string optionName = "arg";
+		const string optionValue = "too-large-string-value";
+
+		var args = new[] { nameof(AppWithValidationAttributes.StrLength), $"--{optionName}", optionValue };
+		Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<AppWithValidationAttributes>(args);
+
+		// Validation fails, so StrLength command is not executed.
+		console.Output.Should().NotContain(AppWithValidationAttributes.StrLengthOutput);
+
+		console.Output.Should().Contain(optionName);
+		console.Output.Should().Contain(optionValue);
+	}
+
+	/// <inheritdoc />
+	internal class AppWithValidationAttributes : ConsoleAppBase
+	{
+		public const string StrLengthOutput = $"hello from {nameof(StrLength)}";
+
+		public void StrLength([StringLength(maximumLength: 8)] string arg) => Console.WriteLine(StrLengthOutput);
+	}
+}


### PR DESCRIPTION
Implemented an ability to validate commands' parameters via validation attributes from `System.ComponentModel.DataAnnotations` namespace and custom ones inheriting `ValidationAttribute` type

Example:

```c#
using System.ComponentModel.DataAnnotations;
// ...

/// <inheritdoc />
internal class TestConsoleApp : ConsoleAppBase
{
    public const string Output = $"hello from {nameof(TestConsoleApp)}";

    [Command(nameof(SomeCommand))]
    public void SomeCommand(
        [EmailAddress] string firstArg,
        [Range(0, 2)]  int secondArg) => Console.WriteLine(Output);
}
```

Output (command invoked with params [**--first-arg "invalid-email-address" --second-arg" 10**])

```
Some parameters have invalid values:
first-arg (invalid-email-address): The String field is not a valid e-mail address.
second-arg (10): The field Int32 must be between 0 and 2.
```