### PR TITLE
error 'Index was outside the bounds of the array'

### DIFF
--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -478,6 +478,11 @@ namespace ConsoleAppFramework
                     }
                     else
                     {
+                        if (args.Length <= i)
+                        {
+                            throw new ArgumentException($@"Value for parameter ""{key}"" is not provided.");
+                        }
+
                         var value = args[i];
                         dict.Add(key, new OptionParameter { Value = value });
                         i++;

--- a/tests/ConsoleAppFramework.Tests/Integration/SingleCommandTest.Options.cs
+++ b/tests/ConsoleAppFramework.Tests/Integration/SingleCommandTest.Options.cs
@@ -203,7 +203,7 @@ namespace ConsoleAppFramework.Integration.Test
         public void Attempt_To_Call_Without_Parameter_Value()
         {
             using var console = new CaptureConsoleOutput();
-            var args = new[] { "--hello", "--name" };
+            var args = new[] { "--name" };
             Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<CommandTests_Single_OptionalBoolAndRequiredOtherOption_NoArgs>(args);
             console.Output.Should().Contain(@"Value for parameter ""name"" is not provided.");
         }

--- a/tests/ConsoleAppFramework.Tests/Integration/SingleCommandTest.Options.cs
+++ b/tests/ConsoleAppFramework.Tests/Integration/SingleCommandTest.Options.cs
@@ -199,6 +199,15 @@ namespace ConsoleAppFramework.Integration.Test
             console.Output.Should().Contain("Hello Cysharp");
         }
 
+        [Fact]
+        public void Attempt_To_Call_Without_Parameter_Value()
+        {
+            using var console = new CaptureConsoleOutput();
+            var args = new[] { "--hello", "--name" };
+            Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<CommandTests_Single_OptionalBoolAndRequiredOtherOption_NoArgs>(args);
+            console.Output.Should().Contain(@"Value for parameter ""name"" is not provided.");
+        }
+
         public class CommandTests_Single_OptionalBoolAndRequiredOtherOption_NoArgs : ConsoleAppBase
         {
             public void Hello(string name, bool hello = false) => Console.WriteLine($"{(hello ? "Hello" : "Konnichiwa")} {name}");


### PR DESCRIPTION
When command parameter name is provided without value, engine crashes with error 'Index was outside the bounds of the array' instead of writing informative message to output

Example:
```csharp
public class TestConsoleApp : ConsoleAppBase
{
    public void Hello(string name) => Console.WriteLine($"hello {name}");
}
```
If app is executed as "MyApp.exe --name" (value for 'name' is not provided):
```
ConsoleAppFramework.ConsoleApp[0]
Index was outside the bounds of the array. args: --hello --name
```


This PR fixes this small issue