### PR TITLE
improve parsing of command-line arguments

### DIFF
--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -373,10 +373,24 @@ namespace ConsoleAppFramework
                             }
                             else
                             {
+                                var v = value.Value;
                                 try
                                 {
-                                    invokeArgs[i] = JsonSerializer.Deserialize(value.Value, parameters[i].ParameterType, jsonOption);
-                                    continue;
+                                    try
+                                    {
+                                        invokeArgs[i] = JsonSerializer.Deserialize(v, parameters[i].ParameterType, jsonOption);
+                                        continue;
+                                    }
+                                    catch (JsonException)
+                                    {
+                                        // retry with double quotations
+                                        if (!(v.StartsWith("\"") && v.EndsWith("\"")))
+                                        {
+                                            v = $"\"{v}\"";
+                                        }
+                                        invokeArgs[i] = JsonSerializer.Deserialize(v, parameters[i].ParameterType, jsonOption);
+                                        continue;
+                                    }
                                 }
                                 catch
                                 {

--- a/tests/ConsoleAppFramework.Tests/Integration/SingleCommandTest.Arguments.cs
+++ b/tests/ConsoleAppFramework.Tests/Integration/SingleCommandTest.Arguments.cs
@@ -127,5 +127,28 @@ namespace ConsoleAppFramework.Integration.Test
         {
             public void Hello([Option(0)]string name = "Anonymous") => Console.WriteLine($"Hello {name}");
         }
+
+        [Fact]
+        public void CommandTests_Single_DateTimeOption_WithDoubleQuote()
+        {
+            using var console = new CaptureConsoleOutput();
+            var args = new[] { "\"2022-07-01\"" };
+            Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<CommandTests_Single_DateTimeOption>(args);
+            console.Output.Trim().Should().Be(@"2022-07-01");
+        }
+
+        [Fact]
+        public void CommandTests_Single_DateTimeOption_WithoutDoubleQuote()
+        {
+            using var console = new CaptureConsoleOutput();
+            var args = new[] { "2022-07-01" };
+            Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<CommandTests_Single_DateTimeOption>(args);
+            console.Output.Trim().Should().Be(@"2022-07-01");
+        }
+
+        public class CommandTests_Single_DateTimeOption: ConsoleAppBase
+        {
+            public void Hello([Option(0)]DateTime dt) => Console.WriteLine($"{dt:yyyy-MM-dd}");
+        }
     }
 }


### PR DESCRIPTION
**Sample Application**

I have a console application that takes a DateTime argument as follows: 

```csharp
var app = ConsoleApp.Create(args);
app.AddRootCommand((DateTime dt) =>
{
    Console.WriteLine($"dt: {dt}");
});
app.Run();
```

**Current Behavior**

`Example 1`: Enclose parameter value in escaped double quotations.

```ps1
> ConsoleApp.exe --dt '\"2022-07-07\"'
# dt: 2022/07/07 0:00:00
```

This will work correctly, but following `Example 2` will not work.

`Example 2`: Parameter value only (without escaped double quotations).

```ps1
> ConsoleApp.exe --dt "2022-07-07"
# Parameter "dt" fail on JSON deserialize, please check type or JSON escape or add double-quotation. args: --dt 2022-07-07
```

**New Behavior**

`Example 1`: Enclose parameter value in escaped double quotations.

```ps1
> ConsoleApp.exe --dt '\"2022-07-07\"'
# dt: 2022/07/07 0:00:00
```

This works correctly as before.

`Example 2`: Parameter value only (without escaped double quotations).

We don't need to enclose parameter values in escaped double quotes now.

```ps1
> ConsoleApp.exe --dt "2022-07-07"
dt: 2022/07/07 0:00:00
```