### PR TITLE
Enable (param string[] something) to accept arbitrary number of parameters.

### DIFF
--- a/src/ConsoleAppFramework/CommandHelpBuilder.cs
+++ b/src/ConsoleAppFramework/CommandHelpBuilder.cs
@@ -298,7 +298,7 @@ namespace ConsoleAppFramework
                 var isFlag = item.ParameterType == typeof(bool);
 
                 var defaultValue = default(string);
-                if (item.HasDefaultValue)
+                if (item.HasDefaultValue())
                 {
                     if (option?.DefaultValue != null)
                     {
@@ -306,16 +306,16 @@ namespace ConsoleAppFramework
                     }
                     else
                     {
-                        defaultValue = (item.DefaultValue?.ToString() ?? "null");
+                        defaultValue = (item.DefaultValue()?.ToString() ?? "null");
                     }
                     if (isFlag)
                     {
-                        if (item.DefaultValue is true)
+                        if (item.DefaultValue() is true)
                         {
                             // bool option with true default value is not flag.
                             isFlag = false;
                         }
-                        else if (item.DefaultValue is false)
+                        else if (item.DefaultValue() is false)
                         {
                             // false default value should be omitted for flag.
                             defaultValue = null;

--- a/src/ConsoleAppFramework/ConsoleApp.cs
+++ b/src/ConsoleAppFramework/ConsoleApp.cs
@@ -174,9 +174,9 @@ namespace ConsoleAppFramework
                 if (method.GetCustomAttribute<RootCommandAttribute>() != null)
                 {
                     var command = new CommandDescriptor(CommandType.DefaultCommand, method);
-                    commands.AddRootCommand(command);
+                    commands.AddSubRootCommand(rootName, command);
                 }
-                else
+                if (method.GetCustomAttribute<CommandAttribute>() != null)
                 {
                     var command = new CommandDescriptor(CommandType.SubCommand, method, parentCommand: rootName);
                     commands.AddSubCommand(rootName, command);

--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -346,13 +346,20 @@ namespace ConsoleAppFramework
                                     var elemType = UnwrapCollectionElementType(parameters[i].ParameterType);
                                     if (elemType == typeof(string))
                                     {
-                                        if (!(v.StartsWith("\"") && v.EndsWith("\"")))
-                                        {
-                                            v = "[" + string.Join(",", v.Split(' ', ',').Select(x => "\"" + x + "\"")) + "]";
+                                        if (parameters.Length == i + 1)
+										{
+                                            v = "[" + string.Join(",", optionByIndex.Skip(parameters[i].Position).Select(x => "\"" + x.Value + "\"")) + "]";
                                         }
                                         else
-                                        {
-                                            v = "[" + v + "]";
+										{
+                                            if (!(v.StartsWith("\"") && v.EndsWith("\"")))
+                                            {
+                                                v = "[" + string.Join(",", v.Split(' ', ',').Select(x => "\"" + x + "\"")) + "]";
+                                            }
+                                            else
+                                            {
+                                                v = "[" + v + "]";
+                                            }
                                         }
                                     }
                                     else

--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -106,7 +106,7 @@ namespace ConsoleAppFramework
             if (commandDescriptor.CommandType == CommandType.DefaultCommand && args.Length == 0)
             {
                 var p = commandDescriptor.MethodInfo.GetParameters();
-                if (p.Any(x => !(x.ParameterType == typeof(ConsoleAppContext) || isService.IsService(x.ParameterType) || x.HasDefaultValue)))
+                if (p.Any(x => !(x.ParameterType == typeof(ConsoleAppContext) || isService.IsService(x.ParameterType) || x.HasDefaultValue())))
                 {
                     options.CommandDescriptors.TryGetHelpMethod(out commandDescriptor);
                 }
@@ -294,7 +294,7 @@ namespace ConsoleAppFramework
                     {
                         if (optionByIndex.Count <= option.Index)
                         {
-                            if (!item.HasDefaultValue)
+                            if (!item.HasDefaultValue())
                             {
                                 throw new InvalidOperationException($"Required argument {option.Index} was not found in specified arguments.");
                             }
@@ -394,9 +394,9 @@ namespace ConsoleAppFramework
                         }
                     }
 
-                    if (item.HasDefaultValue)
+                    if (item.HasDefaultValue())
                     {
-                        invokeArgs[i] = item.DefaultValue;
+                        invokeArgs[i] = item.DefaultValue();
                     }
                     else if (item.ParameterType == typeof(bool))
                     {

--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -347,11 +347,11 @@ namespace ConsoleAppFramework
                                     if (elemType == typeof(string))
                                     {
                                         if (parameters.Length == i + 1)
-										{
+                                        {
                                             v = "[" + string.Join(",", optionByIndex.Skip(parameters[i].Position).Select(x => "\"" + x.Value + "\"")) + "]";
                                         }
                                         else
-										{
+                                        {
                                             if (!(v.StartsWith("\"") && v.EndsWith("\"")))
                                             {
                                                 v = "[" + string.Join(",", v.Split(' ', ',').Select(x => "\"" + x + "\"")) + "]";

--- a/src/ConsoleAppFramework/ConsoleAppFramework.csproj
+++ b/src/ConsoleAppFramework/ConsoleAppFramework.csproj
@@ -18,8 +18,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-		<PackageReference Include="System.Text.Json" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+		<PackageReference Include="System.Text.Json" Version="6.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ConsoleAppFramework/ConsoleAppFramework.csproj
+++ b/src/ConsoleAppFramework/ConsoleAppFramework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net50;net60</TargetFrameworks>
 		<LangVersion>8.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<SignAssembly>true</SignAssembly>

--- a/src/ConsoleAppFramework/ConsoleAppFramework.csproj
+++ b/src/ConsoleAppFramework/ConsoleAppFramework.csproj
@@ -17,8 +17,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-		<PackageReference Include="System.Text.Json" Version="6.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+		<PackageReference Include="System.Text.Json" Version="6.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ConsoleAppFramework/ConsoleAppFramework.csproj
+++ b/src/ConsoleAppFramework/ConsoleAppFramework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp3.1;net50;net60</TargetFrameworks>
+		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 		<LangVersion>8.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<SignAssembly>true</SignAssembly>
@@ -18,8 +18,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-		<PackageReference Include="System.Text.Json" Version="6.0.5" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+		<PackageReference Include="System.Text.Json" Version="6.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ConsoleAppFramework/OptionAttribute.cs
+++ b/src/ConsoleAppFramework/OptionAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace ConsoleAppFramework
 {
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field, AllowMultiple = false)]
     public class OptionAttribute : Attribute
     {
         public int Index { get; }

--- a/src/ConsoleAppFramework/ParameterInfoExtensions.cs
+++ b/src/ConsoleAppFramework/ParameterInfoExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ConsoleAppFramework
+{
+	public static class ParameterInfoExtensions
+	{
+		public static bool HasDefaultValue(this ParameterInfo pi)
+			=> pi.HasDefaultValue
+			|| pi.CustomAttributes.Any(a => a.AttributeType == typeof(ParamArrayAttribute));
+
+		public static object? DefaultValue(this ParameterInfo pi)
+			=> pi.HasDefaultValue
+			? pi.DefaultValue
+			: Array.CreateInstance(pi.ParameterType.GetElementType()!, 0);
+	}
+}

--- a/src/ConsoleAppFramework/ParameterInfoExtensions.cs
+++ b/src/ConsoleAppFramework/ParameterInfoExtensions.cs
@@ -4,15 +4,15 @@ using System.Reflection;
 
 namespace ConsoleAppFramework
 {
-	public static class ParameterInfoExtensions
-	{
-		public static bool HasDefaultValue(this ParameterInfo pi)
-			=> pi.HasDefaultValue
-			|| pi.CustomAttributes.Any(a => a.AttributeType == typeof(ParamArrayAttribute));
+    public static class ParameterInfoExtensions
+    {
+        public static bool HasDefaultValue(this ParameterInfo pi)
+            => pi.HasDefaultValue
+            || pi.CustomAttributes.Any(a => a.AttributeType == typeof(ParamArrayAttribute));
 
-		public static object? DefaultValue(this ParameterInfo pi)
-			=> pi.HasDefaultValue
-			? pi.DefaultValue
-			: Array.CreateInstance(pi.ParameterType.GetElementType()!, 0);
-	}
+        public static object? DefaultValue(this ParameterInfo pi)
+            => pi.HasDefaultValue
+            ? pi.DefaultValue
+            : Array.CreateInstance(pi.ParameterType.GetElementType()!, 0);
+    }
 }

--- a/src/ConsoleAppFramework/ParamsValidator.cs
+++ b/src/ConsoleAppFramework/ParamsValidator.cs
@@ -7,69 +7,69 @@ using System.Reflection;
 
 namespace ConsoleAppFramework
 {
-	/// <summary>
-	/// Validator of command parameters.
-	/// </summary>
-	public interface IParamsValidator
-	{
-		/// <summary>
-		/// Validate <paramref name="parameters"/> of command based on validation attributes
-		/// applied to method's parameters.
-		/// </summary>
-		ValidationResult? ValidateParameters(IEnumerable<(ParameterInfo Parameter, object? Value)> parameters);
-	}
+    /// <summary>
+    /// Validator of command parameters.
+    /// </summary>
+    public interface IParamsValidator
+    {
+        /// <summary>
+        /// Validate <paramref name="parameters"/> of command based on validation attributes
+        /// applied to method's parameters.
+        /// </summary>
+        ValidationResult? ValidateParameters(IEnumerable<(ParameterInfo Parameter, object? Value)> parameters);
+    }
 
-	/// <inheritdoc />
-	public class ParamsValidator : IParamsValidator
-	{
-		private readonly ConsoleAppOptions options;
+    /// <inheritdoc />
+    public class ParamsValidator : IParamsValidator
+    {
+        private readonly ConsoleAppOptions options;
 
-		public ParamsValidator(ConsoleAppOptions options) => this.options = options;
+        public ParamsValidator(ConsoleAppOptions options) => this.options = options;
 
-		/// <inheritdoc />
-		ValidationResult? IParamsValidator.ValidateParameters(
-			IEnumerable<(ParameterInfo Parameter, object? Value)> parameters)
-		{
-			var invalidParameters = parameters
-				.Select(tuple => (tuple.Parameter, tuple.Value, Result: Validate(tuple.Parameter, tuple.Value)))
-				.Where(tuple => tuple.Result != ValidationResult.Success)
-				.ToImmutableArray();
+        /// <inheritdoc />
+        ValidationResult? IParamsValidator.ValidateParameters(
+            IEnumerable<(ParameterInfo Parameter, object? Value)> parameters)
+        {
+            var invalidParameters = parameters
+                .Select(tuple => (tuple.Parameter, tuple.Value, Result: Validate(tuple.Parameter, tuple.Value)))
+                .Where(tuple => tuple.Result != ValidationResult.Success)
+                .ToImmutableArray();
 
-			if (!invalidParameters.Any())
-			{
-				return ValidationResult.Success;
-			}
+            if (!invalidParameters.Any())
+            {
+                return ValidationResult.Success;
+            }
 
-			var errorMessage = string.Join(Environment.NewLine,
-				invalidParameters
-					.Select(tuple => 
-						$"{options.NameConverter(tuple.Parameter.Name!)} " +
-						$"({tuple.Value}): " +
-						$"{tuple.Result!.ErrorMessage}")
-			);
+            var errorMessage = string.Join(Environment.NewLine,
+                invalidParameters
+                    .Select(tuple =>
+                        $"{options.NameConverter(tuple.Parameter.Name!)} " +
+                        $"({tuple.Value}): " +
+                        $"{tuple.Result!.ErrorMessage}")
+            );
 
-			return new ValidationResult($"Some parameters have invalid values:{Environment.NewLine}{errorMessage}");
-		}
+            return new ValidationResult($"Some parameters have invalid values:{Environment.NewLine}{errorMessage}");
+        }
 
-		private static ValidationResult? Validate(ParameterInfo parameterInfo, object? value)
-		{
-			if (value is null) return ValidationResult.Success;
+        private static ValidationResult? Validate(ParameterInfo parameterInfo, object? value)
+        {
+            if (value is null) return ValidationResult.Success;
 
-			var validationContext = new ValidationContext(value, null, null);
+            var validationContext = new ValidationContext(value, null, null);
 
-			var failedResults = GetValidationAttributes(parameterInfo)
-				.Select(attribute => attribute.GetValidationResult(value, validationContext))
-				.Where(result => result != ValidationResult.Success)
-				.ToImmutableArray();
+            var failedResults = GetValidationAttributes(parameterInfo)
+                .Select(attribute => attribute.GetValidationResult(value, validationContext))
+                .Where(result => result != ValidationResult.Success)
+                .ToImmutableArray();
 
-			return failedResults.Any()
-				? new ValidationResult(string.Join("; ", failedResults.Select(res => res?.ErrorMessage)))
-				: ValidationResult.Success;
-		}
+            return failedResults.Any()
+                ? new ValidationResult(string.Join("; ", failedResults.Select(res => res?.ErrorMessage)))
+                : ValidationResult.Success;
+        }
 
-		private static IEnumerable<ValidationAttribute> GetValidationAttributes(ParameterInfo parameterInfo)
-			=> parameterInfo
-				.GetCustomAttributes()
-				.OfType<ValidationAttribute>();
-	}
+        private static IEnumerable<ValidationAttribute> GetValidationAttributes(ParameterInfo parameterInfo)
+            => parameterInfo
+                .GetCustomAttributes()
+                .OfType<ValidationAttribute>();
+    }
 }


### PR DESCRIPTION
For declaring some command like this
`[Command("run", "Run commandlet.")] public async Task RunCommandlet([Option(0)] string commandlet, [Option(1)] params string[] parameters)`
if last indexed parameter is params then it will accept all leftover parameters from command line

For example `myprog run CommandletName param1 param2` - param1 param2 will be put to parameters array
In case of `myprog run CommandletName` - parameters will be empty.

Sorry for big diff. converted all tabs to spaces as it should be in whole projec.t
