### PR TITLE
Enable (param string[] something) to accept arbitrary number of parameters. 

### DIFF
--- a/src/ConsoleAppFramework/CommandHelpBuilder.cs
+++ b/src/ConsoleAppFramework/CommandHelpBuilder.cs
@@ -305,7 +305,7 @@ namespace ConsoleAppFramework
                 var isFlag = item.ParameterType == typeof(bool);
 
                 var defaultValue = default(string);
-                if (item.HasDefaultValue)
+                if (item.HasDefaultValue())
                 {
                     if (option?.DefaultValue != null)
                     {
@@ -313,16 +313,16 @@ namespace ConsoleAppFramework
                     }
                     else
                     {
-                        defaultValue = (item.DefaultValue?.ToString() ?? "null");
+                        defaultValue = (item.DefaultValue()?.ToString() ?? "null");
                     }
                     if (isFlag)
                     {
-                        if (item.DefaultValue is true)
+                        if (item.DefaultValue() is true)
                         {
                             // bool option with true default value is not flag.
                             isFlag = false;
                         }
-                        else if (item.DefaultValue is false)
+                        else if (item.DefaultValue() is false)
                         {
                             // false default value should be omitted for flag.
                             defaultValue = null;

--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -106,7 +106,7 @@ namespace ConsoleAppFramework
             if (commandDescriptor.CommandType == CommandType.DefaultCommand && args.Length == 0)
             {
                 var p = commandDescriptor.MethodInfo.GetParameters();
-                if (p.Any(x => !(x.ParameterType == typeof(ConsoleAppContext) || isService.IsService(x.ParameterType) || x.HasDefaultValue)))
+                if (p.Any(x => !(x.ParameterType == typeof(ConsoleAppContext) || isService.IsService(x.ParameterType) || x.HasDefaultValue())))
                 {
                     options.CommandDescriptors.TryGetHelpMethod(out commandDescriptor);
                 }
@@ -294,7 +294,7 @@ namespace ConsoleAppFramework
                     {
                         if (optionByIndex.Count <= option.Index)
                         {
-                            if (!item.HasDefaultValue)
+                            if (!item.HasDefaultValue())
                             {
                                 throw new InvalidOperationException($"Required argument {option.Index} was not found in specified arguments.");
                             }
@@ -346,13 +346,20 @@ namespace ConsoleAppFramework
                                     var elemType = UnwrapCollectionElementType(parameters[i].ParameterType);
                                     if (elemType == typeof(string))
                                     {
-                                        if (!(v.StartsWith("\"") && v.EndsWith("\"")))
-                                        {
-                                            v = "[" + string.Join(",", v.Split(' ', ',').Select(x => "\"" + x + "\"")) + "]";
+                                        if (parameters.Length == i + 1)
+										{
+                                            v = "[" + string.Join(",", optionByIndex.Skip(parameters[i].Position).Select(x => "\"" + x.Value + "\"")) + "]";
                                         }
                                         else
-                                        {
-                                            v = "[" + v + "]";
+										{
+                                            if (!(v.StartsWith("\"") && v.EndsWith("\"")))
+                                            {
+                                                v = "[" + string.Join(",", v.Split(' ', ',').Select(x => "\"" + x + "\"")) + "]";
+                                            }
+                                            else
+                                            {
+                                                v = "[" + v + "]";
+                                            }
                                         }
                                     }
                                     else
@@ -401,9 +408,9 @@ namespace ConsoleAppFramework
                         }
                     }
 
-                    if (item.HasDefaultValue)
+                    if (item.HasDefaultValue())
                     {
-                        invokeArgs[i] = item.DefaultValue;
+                        invokeArgs[i] = item.DefaultValue();
                     }
                     else if (item.ParameterType == typeof(bool))
                     {

--- a/src/ConsoleAppFramework/ParameterInfoExtensions.cs
+++ b/src/ConsoleAppFramework/ParameterInfoExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ConsoleAppFramework
+{
+	public static class ParameterInfoExtensions
+	{
+		public static bool HasDefaultValue(this ParameterInfo pi)
+			=> pi.HasDefaultValue
+			|| pi.CustomAttributes.Any(a => a.AttributeType == typeof(ParamArrayAttribute));
+
+		public static object? DefaultValue(this ParameterInfo pi)
+			=> pi.HasDefaultValue
+			? pi.DefaultValue
+			: Array.CreateInstance(pi.ParameterType.GetElementType()!, 0);
+	}
+}


### PR DESCRIPTION
For declaring some command like this
`[Command("run", "Run commandlet.")] public async Task RunCommandlet([Option(0)] string commandlet, [Option(1)] params string[] parameters)`
if last indexed parameter is params then it will accept all leftover parameters from command line

For example myprog run CommandletName param1 param2 - param1 param2 will be put to parameters array
In case of myprog run CommandletName - parameters will be empty.