### PR TITLE
Implement command alias only for methods

### DIFF
--- a/src/ConsoleAppFramework/CommandDescriptor.cs
+++ b/src/ConsoleAppFramework/CommandDescriptor.cs
@@ -49,11 +49,11 @@ namespace ConsoleAppFramework
         {
             if (ParentCommand != null)
             {
-                return $"{ParentCommand} {GetNamesFormatted(options)}";
+                return $"{ParentCommand} {GetNames(options)[0]}";
             }
             else
             {
-                return GetNamesFormatted(options);
+                return GetNames(options)[0];
             }
         }
 

--- a/src/ConsoleAppFramework/CommandHelpBuilder.cs
+++ b/src/ConsoleAppFramework/CommandHelpBuilder.cs
@@ -11,13 +11,15 @@ namespace ConsoleAppFramework
     internal class CommandHelpBuilder
     {
         readonly Func<string> getExecutionCommandName;
+        readonly Func<string[]> getExecutionCommandAliases;
         readonly bool isStrictOption;
         readonly IServiceProviderIsService isService;
         readonly ConsoleAppOptions options;
 
-        public CommandHelpBuilder(Func<string>? getExecutionCommandName, IServiceProviderIsService isService, ConsoleAppOptions options)
+        public CommandHelpBuilder(Func<string>? getExecutionCommandName, Func<string[]>? getExecutionCommandAliases, IServiceProviderIsService isService, ConsoleAppOptions options)
         {
             this.getExecutionCommandName = getExecutionCommandName ?? GetExecutionCommandNameDefault;
+            this.getExecutionCommandAliases = getExecutionCommandAliases ?? (() => new string[0]);
             this.isStrictOption = options.StrictOption;
             this.isService = isService;
             this.options = options;
@@ -93,6 +95,13 @@ namespace ConsoleAppFramework
                 sb.AppendLine("Options:");
                 sb.AppendLine("  ()");
                 sb.AppendLine();
+            }
+
+            var aliases = getExecutionCommandAliases();
+            if(aliases.Length > 0)
+            {
+                sb.Append("Aliases: ");
+                sb.AppendLine(string.Join(", ", aliases));
             }
 
             return sb.ToString();

--- a/src/ConsoleAppFramework/CommandHelpBuilder.cs
+++ b/src/ConsoleAppFramework/CommandHelpBuilder.cs
@@ -231,7 +231,7 @@ namespace ConsoleAppFramework
         internal string BuildMethodListMessage(IEnumerable<CommandHelpDefinition> commandHelpDefinitions, bool appendCommand, out int maxWidth)
         {
             var formatted = commandHelpDefinitions
-                .Select(x => (Command: $"{(x.CommandAliases.Length != 0 ? ((appendCommand ? x.Command + " " : "") + string.Join(", ", x.CommandAliases)) : x.Command)}", Description: x.Description))
+                .Select(x => (Command: x.Command, Description: x.Description))
                 .ToArray();
             maxWidth = formatted.Max(x => x.Command.Length);
 
@@ -349,7 +349,7 @@ namespace ConsoleAppFramework
             }
 
             return new CommandHelpDefinition(
-                shortCommandName ? descriptor.GetNamesFormatted(options) : descriptor.GetCommandName(options),
+                shortCommandName ? descriptor.GetNames(options)[0] : descriptor.GetCommandName(options),
                 descriptor.Aliases,
                 parameterDefinitions.OrderBy(x => x.Index ?? int.MaxValue).ToArray(),
                 descriptor.Description

--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -83,7 +83,11 @@ namespace ConsoleAppFramework
                     var subCommands = options.CommandDescriptors.GetSubCommands(args[0]);
                     if (subCommands.Length != 0)
                     {
-                        var msg = new CommandHelpBuilder(() => args[0], isService, options).BuildHelpMessage(null, subCommands, shortCommandName: true);
+                        var msg = new CommandHelpBuilder(
+                                () => commandDescriptor?.GetCommandName(options) ?? args[0],
+                                () => commandDescriptor?.Aliases ?? new string[0],
+                                isService, options)
+                            .BuildHelpMessage(null, subCommands, shortCommandName: true);
                         Console.WriteLine(msg);
                         return;
                     }
@@ -97,7 +101,8 @@ namespace ConsoleAppFramework
             // foo bar --help
             if (args.Skip(offset).FirstOrDefault()?.Trim('-') == "help")
             {
-                var msg = new CommandHelpBuilder(() => commandDescriptor.GetCommandName(options), isService, options).BuildHelpMessage(commandDescriptor);
+                var msg = new CommandHelpBuilder(() => commandDescriptor.GetCommandName(options), () => commandDescriptor.Aliases, isService, options)
+                    .BuildHelpMessage(commandDescriptor);
                 Console.WriteLine(msg);
                 return;
             }

--- a/src/ConsoleAppFramework/DefaultCommands.cs
+++ b/src/ConsoleAppFramework/DefaultCommands.cs
@@ -32,7 +32,7 @@ namespace ConsoleAppFramework
             {
                 descriptors = descriptors.Where(x => x != HelpCommand && x != VersionCommand);
             }
-            var message = new CommandHelpBuilder(null,isService, options).BuildHelpMessage(options.CommandDescriptors.GetRootCommandDescriptor(), descriptors, shortCommandName: false);
+            var message = new CommandHelpBuilder(null, null, isService, options).BuildHelpMessage(options.CommandDescriptors.GetRootCommandDescriptor(), descriptors, shortCommandName: false);
             Console.WriteLine(message);
         }
 

--- a/tests/ConsoleAppFramework.Tests/Integration/SingleCommandTest.CommandAliases.cs
+++ b/tests/ConsoleAppFramework.Tests/Integration/SingleCommandTest.CommandAliases.cs
@@ -1,0 +1,72 @@
+using System;
+using FluentAssertions;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+
+namespace ConsoleAppFramework.Integration.Test
+{
+    public partial class SingleCommandTest
+    {
+        [Fact]
+        public void CommandAliases_CommandIsNotSpecified()
+        {
+            using var console = new CaptureConsoleOutput();
+            var args = new string[] { };
+            Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<CommandTests_Single_Aliased>(args);
+            console.Output.Should().Contain("Usage:");
+            console.Output.Should().Contain("Commands:");
+            console.Output.Should().Contain("alias-1");
+            console.Output.Should().NotContain("alias-2");
+        }
+
+        [Fact]
+        public void CommandAliases_Invoke_1()
+        {
+            using var console = new CaptureConsoleOutput();
+            var args = new string[] { "alias-1" };
+            Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<CommandTests_Single_Aliased>(args);
+            console.Output.Should().Contain("Hello");
+        }
+
+        [Fact]
+        public void CommandAliases_Invoke_2()
+        {
+            using var console = new CaptureConsoleOutput();
+            var args = new string[] { "alias-2" };
+            Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<CommandTests_Single_Aliased>(args);
+            console.Output.Should().Contain("Hello");
+        }
+
+        [Fact]
+        public void CommandAliases_CommandHelp_1()
+        {
+            using var console = new CaptureConsoleOutput();
+            var args = new string[] { "alias-1", "help" };
+            Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<CommandTests_Single_Aliased>(args);
+            console.Output.Should().Contain("Usage: ");
+            console.Output.Should().MatchRegex("alias-1(?!([, ]*alias-2))");
+            console.Output.Should().Contain("Aliases: alias-2");
+            console.Output.Should().NotContain("alias-2, alias-2");
+        }
+
+        [Fact]
+        public void CommandAliases_CommandHelp_2()
+        {
+            using var console = new CaptureConsoleOutput();
+            var args = new string[] { "alias-2", "help" };
+            Host.CreateDefaultBuilder().RunConsoleAppFrameworkAsync<CommandTests_Single_Aliased>(args);
+            console.Output.Should().Contain("Usage: ");
+            console.Output.Should().MatchRegex("alias-1(?!([, ]*alias-2))");
+            console.Output.Should().Contain("Aliases: alias-2");
+            console.Output.Should().NotContain("alias-2, alias-2");
+        }
+
+        public class CommandTests_Single_Aliased : ConsoleAppBase
+        {
+            [Command(new[] { "alias-1", "alias-2" })]
+            public void Hello() => Console.WriteLine("Hello");
+        }
+    }
+}

--- a/tests/ConsoleAppFramework.Tests/Legacy/CommandHelpTest.cs
+++ b/tests/ConsoleAppFramework.Tests/Legacy/CommandHelpTest.cs
@@ -10,9 +10,9 @@ namespace ConsoleAppFramework.Tests
 {
     public class CommandHelpTest
     {
-        private CommandHelpBuilder CreateCommandHelpBuilder() => new CommandHelpBuilder(() => "Nantoka", null, new ConsoleAppOptions() { NameConverter = x => x.ToLower() });
-        private CommandHelpBuilder CreateCommandHelpBuilder2() => new CommandHelpBuilder(() => "Nantoka", null, new ConsoleAppOptions() { NameConverter = x => x.ToLower() });
-        private CommandHelpBuilder CreateCommandHelpBuilder3() => new CommandHelpBuilder(() => "Nantoka", null, new ConsoleAppOptions() { NameConverter = x => x.ToLower() });
+        private CommandHelpBuilder CreateCommandHelpBuilder() => new CommandHelpBuilder(() => "Nantoka", null, null, new ConsoleAppOptions() { NameConverter = x => x.ToLower() });
+        private CommandHelpBuilder CreateCommandHelpBuilder2() => new CommandHelpBuilder(() => "Nantoka", null, null, new ConsoleAppOptions() { NameConverter = x => x.ToLower() });
+        private CommandHelpBuilder CreateCommandHelpBuilder3() => new CommandHelpBuilder(() => "Nantoka", null, null, new ConsoleAppOptions() { NameConverter = x => x.ToLower() });
 
         [Fact]
         public void BuildMethodListMessage()


### PR DESCRIPTION
## Problems

`CommandAttribute` has a constructor with multiple names (hereinafter called aliases), but it still has some problems. I guess that's the reason it's not officially introduced in readme.md.

1. Aliases are shown twice in command helps (related to #96)
2. Aliases doesn't work for classes
3. If [2] above got solved, command help messages would be hard to read.

<details>
<summary>An example for [3]</summary>

code:

```csharp
[Command(new[] {"class1", "class2"})]
class App : ConsoleAppBase
{
    [Command(new[] { "command1", "command2" }, "desc")]
    public void Sample()
    {
        Console.WriteLine("Hello!");
    }
}
```

The help text for the code above would be:
```text
class1, class2 command1, command2    desc
```

It's hard to see which is the parent's name and which is the method's at a glance.
</details>

## What this PR will do

To solve [1] and [3], this PR will:

- not show aliases in command list in help messages

- add "Aliases: ..." line to the help text for commands which have aliases

```shell
$ myapp.exe command-name --help 
Usage: command-name

Print "Hello, world!"

Options:
  ()

Aliases: command-alias-1, command-alias-2
```

- add tests for these changes

## What this PR won't do:

- Fix the problem [2]: It was hard for me to fix it.