### PR TITLE
Changed generic add methods so that they support parent class method inheritence

### DIFF
--- a/src/ConsoleAppFramework/ConsoleApp.cs
+++ b/src/ConsoleAppFramework/ConsoleApp.cs
@@ -128,7 +128,7 @@ namespace ConsoleAppFramework
         public ConsoleApp AddCommands<T>()
             where T : ConsoleAppBase
         {
-            var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance);
             foreach (var method in methods)
             {
                 if (method.Name == "Dispose" || method.Name == "DisposeAsync") continue; // ignore IDisposable
@@ -163,7 +163,7 @@ namespace ConsoleAppFramework
 
         public ConsoleApp AddSubCommands<T>()
         {
-            var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance);
 
             var rootName = typeof(T).GetCustomAttribute<CommandAttribute>()?.CommandNames[0] ?? options.NameConverter(typeof(T).Name);
 
@@ -194,7 +194,7 @@ namespace ConsoleAppFramework
         {
             foreach (var type in GetConsoleAppTypes(searchAssemblies))
             {
-                var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
                 var rootName = type.GetCustomAttribute<CommandAttribute>()?.CommandNames[0] ?? options.NameConverter(type.Name);
                 foreach (var method in methods)
                 {


### PR DESCRIPTION
Removed BindingFlags.DeclaredOnly from generic add methods so that they can populate inherited public methods.

Not sure why it was originally included as it makes stuff like creating bulk repository access classes annoying to code since each one has to basically re-implement all the commands instead of inheriting from a generic base class that exposes the commands.