### PR TITLE
Added support for class inheritence for command classes

### DIFF
--- a/src/ConsoleAppFramework/CommandDescriptorCollection.cs
+++ b/src/ConsoleAppFramework/CommandDescriptorCollection.cs
@@ -41,11 +41,13 @@ namespace ConsoleAppFramework
                 subCommandDescriptors.Add(parentCommand, commandDict);
             }
 
-            foreach (var name in commandDescriptor.GetNames(options))
+            var names = commandDescriptor.GetNames(options);
+
+            foreach (var name in names)
             {
                 if (!commandDict.TryAdd(name, commandDescriptor))
                 {
-                    throw new InvalidOperationException($"Duplicate command name is added. Name:{parentCommand} {name} Method:{commandDescriptor.MethodInfo.DeclaringType?.Name}.{commandDescriptor.MethodInfo.Name}");
+                    throw new InvalidOperationException($"Duplicate command name is added. Name:{parentCommand} {name} Method:{commandDescriptor.MethodInfo.ReflectedType?.Name}.{commandDescriptor.MethodInfo.Name}");
                 }
             }
         }

--- a/src/ConsoleAppFramework/ConsoleApp.cs
+++ b/src/ConsoleAppFramework/ConsoleApp.cs
@@ -128,7 +128,7 @@ namespace ConsoleAppFramework
         public ConsoleApp AddCommands<T>()
             where T : ConsoleAppBase
         {
-            var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance);
             foreach (var method in methods)
             {
                 if (method.Name == "Dispose" || method.Name == "DisposeAsync") continue; // ignore IDisposable
@@ -163,7 +163,7 @@ namespace ConsoleAppFramework
 
         public ConsoleApp AddSubCommands<T>()
         {
-            var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance);
 
             var rootName = typeof(T).GetCustomAttribute<CommandAttribute>()?.CommandNames[0] ?? options.NameConverter(typeof(T).Name);
 
@@ -194,7 +194,7 @@ namespace ConsoleAppFramework
         {
             foreach (var type in GetConsoleAppTypes(searchAssemblies))
             {
-                var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
                 var rootName = type.GetCustomAttribute<CommandAttribute>()?.CommandNames[0] ?? options.NameConverter(type.Name);
                 foreach (var method in methods)
                 {

--- a/src/ConsoleAppFramework/ConsoleApp.cs
+++ b/src/ConsoleAppFramework/ConsoleApp.cs
@@ -16,10 +16,8 @@ namespace ConsoleAppFramework
         // Keep this reference as ConsoleApOptions.CommandDescriptors.
         readonly CommandDescriptorCollection commands;
         readonly ConsoleAppOptions options;
-        readonly string[] invalidMethodNames =
+        readonly string[] notInheritedMethods =
         {
-            "Dispose",
-            "DisposeAsync",
             "GetType",
             "ToString",
             "Equals",
@@ -137,11 +135,13 @@ namespace ConsoleAppFramework
         public ConsoleApp AddCommands<T>()
             where T : ConsoleAppBase
         {
+            var type = typeof(T);
+
             var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance).Where(m => !m.IsSpecialName);
 
             foreach (var method in methods)
             {
-                if (invalidMethodNames.Contains(method.Name)) continue;
+                if (notInheritedMethods.Contains(method.Name) && method.DeclaringType != type) continue;
 
                 if (method.GetCustomAttribute<RootCommandAttribute>() != null || (options.NoAttributeCommandAsImplicitlyDefault && method.GetCustomAttribute<CommandAttribute>() == null))
                 {
@@ -173,13 +173,15 @@ namespace ConsoleAppFramework
 
         public ConsoleApp AddSubCommands<T>()
         {
+            var type = typeof(T);
+
             var methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Instance).Where(m => !m.IsSpecialName);
 
             var rootName = typeof(T).GetCustomAttribute<CommandAttribute>()?.CommandNames[0] ?? options.NameConverter(typeof(T).Name);
 
             foreach (var method in methods)
             {
-                if (invalidMethodNames.Contains(method.Name)) continue;
+                if (notInheritedMethods.Contains(method.Name) && method.DeclaringType != type) continue;
 
                 if (method.GetCustomAttribute<RootCommandAttribute>() != null)
                 {

--- a/src/ConsoleAppFramework/ConsoleAppEngine.cs
+++ b/src/ConsoleAppFramework/ConsoleAppEngine.cs
@@ -113,7 +113,7 @@ namespace ConsoleAppFramework
             }
 
         RUN:
-            await RunCore(commandDescriptor!.MethodInfo!.DeclaringType!, commandDescriptor.MethodInfo, commandDescriptor.Instance, args, offset);
+            await RunCore(commandDescriptor!.MethodInfo!.ReflectedType!, commandDescriptor.MethodInfo, commandDescriptor.Instance, args, offset);
         }
 
         // Try to invoke method.


### PR DESCRIPTION
Removed BindingFlags.DeclaredOnly from generic add methods and changed DeclaringType to ReflectedType in ConsoleAppEngine. This allows the use of command classes that inherit their commands form a parent class.

(last one I swear... pretty sure I tracked down all the bugs)

This update no longer hides the dispose methods, I recommend implicitly implementing the interface so they don't show up. It has a list of not allowed to inherit methods, but is implemented in a way that allows those methods to still show up in the console list if they're explicitly defined in the class for whatever reason (we don't check args, so you could have an Equals method for example that does something completely different than normal.)