### PR TITLE
Improve grammar of exceptions

### DIFF
--- a/src/ConsoleAppFramework/ConsoleAppGenerator.cs
+++ b/src/ConsoleAppFramework/ConsoleAppGenerator.cs
@@ -175,17 +175,17 @@ internal static partial class ConsoleApp
 
     static void ThrowArgumentParseFailed(string argumentName, string value)
     {
-        throw new ArgumentException($"Argument '{argumentName}' parse failed. value: {value}");
+        throw new ArgumentException($"Argument '{argumentName}' failed to parse, provided value: {value}");
     }
 
     static void ThrowRequiredArgumentNotParsed(string name)
     {
-        throw new ArgumentException($"Require argument '{name}' does not parsed.");
+        throw new ArgumentException($"Required argument '{name}' was not specified.");
     }
 
     static void ThrowArgumentNameNotFound(string argumentName)
     {
-        throw new ArgumentException($"Argument '{argumentName}' does not found in command prameters.");
+        throw new ArgumentException($"Argument '{argumentName}' is not recognized.");
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
I've noticed the value printed in `ThrowArgumentParseFailed` may not be correct in some cases, like when `TryIncrementIndex` fails, it will print the argument name itself, rather than the value (because there isn't one). Maybe this should be special cased to a new exception like `Argument '{argumentName}' requires a value, but none was specified.`?

