### PR TITLE
Rename ClassDeclarationSyntax variable from primartyCtor to primaryCtor

### DIFF
--- a/src/ConsoleAppFramework/RoslynExtensions.cs
+++ b/src/ConsoleAppFramework/RoslynExtensions.cs
@@ -73,9 +73,9 @@ internal static class RoslynExtensions
         {
             return ctor.ParameterList;
         }
-        else if (node is ClassDeclarationSyntax primartyCtor)
+        else if (node is ClassDeclarationSyntax primaryCtor)
         {
-            return primartyCtor.ParameterList;
+            return primaryCtor.ParameterList;
         }
         else
         {


### PR DESCRIPTION
Use correct spelling for `ClassDeclarationSyntax` variable