### PR TITLE
Ignore attribute

### DIFF
--- a/src/ConsoleAppFramework/ConsoleAppGenerator.cs
+++ b/src/ConsoleAppFramework/ConsoleAppGenerator.cs
@@ -144,7 +144,7 @@ internal sealed class ArgumentAttribute : Attribute
 {
 }
 
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class CommandAttribute : Attribute
 {
     public string Command { get; }

--- a/src/ConsoleAppFramework/ConsoleAppGenerator.cs
+++ b/src/ConsoleAppFramework/ConsoleAppGenerator.cs
@@ -144,7 +144,7 @@ internal sealed class ArgumentAttribute : Attribute
 {
 }
 
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class CommandAttribute : Attribute
 {
     public string Command { get; }
@@ -153,6 +153,11 @@ internal sealed class CommandAttribute : Attribute
     {
         this.Command = command;
     }
+}
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+internal sealed class IgnoreAttribute : Attribute
+{
 }
 
 internal static partial class ConsoleApp

--- a/src/ConsoleAppFramework/Parser.cs
+++ b/src/ConsoleAppFramework/Parser.cs
@@ -138,6 +138,7 @@ internal class Parser(DiagnosticReporter context, InvocationExpressionSyntax nod
         };
 
         return publicMethods
+            .Where(x => !x.GetAttributes().Any(y => y.AttributeClass?.Name == "IgnoreAttribute"))
             .Select(x =>
             {
                 string commandName;

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -142,8 +142,8 @@ public class TestInfo {
 
 public abstract class TestBase
 {
-    public abstract TestInfo PrintInfo();
-    public virtual void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{PrintInfo().TestName} : {value}");
+    public abstract TestInfo GetTestInfo();
+    public virtual void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{GetTestInfo().TestName} : {value}");
 }
 
 public class Test : TestBase
@@ -151,10 +151,10 @@ public class Test : TestBase
     // This will fail at compile time with the error code CAF003
     // By adding the Ignore Attribute we prevent this compiler error as it then will not be included as a command
     [Ignore]
-    public override TestInfo PrintInfo() => new TestInfo() { TestName = "Test1" };
+    public override TestInfo GetTestInfo() => new TestInfo() { TestName = "Test1" };
     public override void Show(string aaa, [Range(0, 1)] double value){
         base.Show(aaa, value);
-        ConsoleApp.Log($"{PrintInfo().TestName}x2 : {value * 2}");
+        ConsoleApp.Log($"{GetTestInfo().TestName}x2 : {value * 2}");
     }
 }
 

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -143,16 +143,19 @@ public class TestInfo {
 public abstract class TestBase
 {
     public abstract TestInfo PrintInfo();
-    public virtual void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{value} : {PrintInfo()}");
+    public virtual void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{PrintInfo().TestName} : {value}");
 }
 
 public class Test : TestBase
 {
-    // This will fail at compiletime with CAF003
-    // By adding the Ignore Attribute we prevent this compile error as it would be included as a command
+    // This will fail at compile time with the error code CAF003
+    // By adding the Ignore Attribute we prevent this compiler error as it then will not be included as a command
     [Ignore]
     public override TestInfo PrintInfo() => new TestInfo() { TestName = "Test1" };
-    public override void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{value}");
+    public override void Show(string aaa, [Range(0, 1)] double value){
+        base.Show(aaa, value);
+        ConsoleApp.Log($"{PrintInfo().TestName}x2 : {value * 2}");
+    }
 }
 
 """, "show --aaa foo --value 100", expected);

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -96,7 +96,7 @@ namespace Takoyaki
          public int Foo { get; set; }
     }
 }
-""", "--foo 10 --bar aiueo --ft Grape --flag --half 1.3 --itt 99 --obj {\"Foo\":1999}", "10aiueoGrapeTrue1.3991999");
+""", "--foo 10 --bar aiueo --ft Grape --flag --half 1.3 --itt 99 --obj {\"Foo\":1999}", "10aiueoGrapeTrue13991999");
     }
 
     [Fact]

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -121,4 +121,38 @@ public class Test
 """, "show --aaa foo --value 100", expected);
 
     }
+
+    [Fact]
+    public void ValidateAbstractClass()
+    {
+        var expected = """
+The field value must be between 0 and 1.
+
+
+""";
+
+        verifier.Execute("""
+var app = ConsoleApp.Create();
+app.Add<Test>();
+app.Run(args);
+
+public class TestInfo {
+    public string TestName { get; set; }
+}
+
+public abstact class TestBase
+{
+    public abstract TestInfo PrintInfo();
+    public virtual void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{value}");
+}
+
+public class Test : TestBase
+{
+    public override TestInfo PrintInfo() => new TestInfo() { TestName = "Test1" };
+    public override void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{value}");
+}
+
+""", "show --aaa foo --value 100", expected);
+
+    }
 }

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -140,14 +140,17 @@ public class TestInfo {
     public string TestName { get; set; }
 }
 
-public abstact class TestBase
+public abstract class TestBase
 {
     public abstract TestInfo PrintInfo();
-    public virtual void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{value}");
+    public virtual void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{value} : {PrintInfo()}");
 }
 
 public class Test : TestBase
 {
+    // This will fail at compiletime with CAF003
+    // By adding the Ignore Attribute we prevent this compile error as it would be included as a command
+    [Ignore]
     public override TestInfo PrintInfo() => new TestInfo() { TestName = "Test1" };
     public override void Show(string aaa, [Range(0, 1)] double value) => ConsoleApp.Log($"{value}");
 }


### PR DESCRIPTION
Allows for classes that have commands to inherit from an abstract class with abstract and or virtual methods, as private methods cannot be abstract or virtual, see [CS0621](https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0621?f1url=%3FappId%3Droslyn%26k%3Dk(CS0621))

When dogfooding for creating a CLI, I needed this and I couldn't think of another way to do this without the compiler complaining.

See the new [test](https://github.com/Cysharp/ConsoleAppFramework/pull/128/files#diff-4527bd76f3ff226ff531f96f278d6183c7921d6e86cdfab98fcb86717987bd3eR126) and its comment for a visual explanation.