### PR TITLE
Subcommands in Help print - Syntax review

### DIFF
--- a/src/ConsoleAppFramework/ConsoleAppGenerator.cs
+++ b/src/ConsoleAppFramework/ConsoleAppGenerator.cs
@@ -144,7 +144,7 @@ internal sealed class ArgumentAttribute : Attribute
 {
 }
 
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
 internal sealed class CommandAttribute : Attribute
 {
     public string Command { get; }

--- a/src/ConsoleAppFramework/ConsoleAppGenerator.cs
+++ b/src/ConsoleAppFramework/ConsoleAppGenerator.cs
@@ -63,7 +63,7 @@ public partial class ConsoleAppGenerator : IIncrementalGenerator
 
                     var expr = invocationExpression.Expression as MemberAccessExpressionSyntax;
                     var methodName = expr?.Name.Identifier.Text;
-                    if (methodName is "Add" or "UseFilter" or "Run" or "RunAsync")
+                    if (methodName is "Add" or "SubcommandHelp" or "UseFilter" or "Run" or "RunAsync")
                     {
                         return true;
                     }
@@ -457,6 +457,12 @@ internal static partial class ConsoleApp
         }
     }
 
+    public enum DisplayType 
+    {
+        Default,
+        Hidden
+    }
+
     internal partial struct ConsoleAppBuilder
     {
         public ConsoleAppBuilder()
@@ -466,6 +472,11 @@ internal static partial class ConsoleApp
         public void Add(string commandName, Delegate command)
         {
             AddCore(commandName, command);
+        }
+
+        public void SubcommandHelp(DisplayType displayType)
+        {
+            // Not Implemented yet
         }
 
         [System.Diagnostics.Conditional("DEBUG")]

--- a/src/ConsoleAppFramework/Parser.cs
+++ b/src/ConsoleAppFramework/Parser.cs
@@ -62,7 +62,7 @@ internal class Parser(DiagnosticReporter context, InvocationExpressionSyntax nod
             var className = genericName.TypeArgumentList.Arguments.First().ToString();
 
             // Find the class declaration with the matching class name
-            var classDeclaration = node.SyntaxTree.GetRoot().DescendantNodes()
+            var classDeclaration = model.SyntaxTree.GetRoot().DescendantNodes()
                 .OfType<ClassDeclarationSyntax>()
                 .FirstOrDefault(c => c.Identifier.Text == className);
 

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -305,4 +305,303 @@ Options:
 
 """);
     }
+
+    [Fact]
+    public void ClassCommandNoClassSummary()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<MyClass>();
+app.Run(args);
+
+[Command("mc")]
+public class MyClass
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World! " + fooBar);
+    }
+}
+""";
+
+        verifier.Execute(code, args: "--help", expected: """
+Usage: mc [command] [options...] [-h|--help] [--version]
+
+Commands:
+  hello-world
+
+""");
+        verifier.Execute(code, args: "hello-world --help", expected: """
+Usage: hello-world [arguments...] [options...] [-h|--help] [--version]
+
+hello my world.
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+""");
+    }
+
+    [Fact]
+    public void ClassCommandWithSummary()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<MyClass>();
+app.Run(args);
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("mc")]
+public class MyClass
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World! " + fooBar);
+    }
+}
+""";
+        verifier.Execute(code, args: "--help", expected: """
+Usage: mc [command] [options...] [-h|--help] [--version]
+
+My class
+
+Commands:
+  hello-world
+
+""");
+
+        verifier.Execute(code, args: "mc hello-world --help", expected: """
+Usage: hello-world [arguments...] [options...] [-h|--help] [--version]
+
+hello my world.
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+""");
+    }
+
+    [Fact]
+    public void AppWithNoRootDefaultDisplaySubcommand()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<MyClass>();
+app.Add<MyClass2>();
+app.SubcommandHelp(DisplayType.Default);
+app.Run(args);
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("mc")]
+public class MyClass
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World! " + fooBar);
+    }
+}
+
+/// <summary>
+/// My class 2
+/// </summary>
+[Command("mc2")]
+public class MyClass2
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld2([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World2! " + fooBar);
+    }
+}
+""";
+        verifier.Execute(code, args: "--help", expected: """
+Usage: [command] [options...] [-h|--help] [--version]
+
+Commands:
+  mc hello-world
+  mc2 hello-world2
+
+""");
+
+        verifier.Execute(code, args: "mc hello-world --help", expected: """
+Usage: hello-world [arguments...] [options...] [-h|--help] [--version]
+
+hello my world.
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+""");
+    }
+
+    [Fact]
+    public void AppWithClassRootWithHiddenSubcommands()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<MyClass>();
+app.Add<MyClass2>();
+app.SubcommandHelp(DisplayType.Hidden);
+app.Run(args);
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("mc")]
+public class MyClass
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World! " + fooBar);
+    }
+}
+
+/// <summary>
+/// My class 2
+/// </summary>
+[Command("mc2")]
+public class MyClass2
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld2([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World2! " + fooBar);
+    }
+}
+""";
+        verifier.Execute(code, args: "--help", expected: """
+Usage: [command] [options...] [-h|--help] [--version]
+
+Commands:
+  mc
+  mc2
+
+""");
+
+        verifier.Execute(code, args: "mc hello-world --help", expected: """
+Usage: hello-world [arguments...] [options...] [-h|--help] [--version]
+
+hello my world.
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+""");
+    }
+
+    [Fact]
+    public void AppWithClassRoot()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<Root>();
+app.Add<MyClass>();
+app.Run(args);
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("")]
+public class Root
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World! " + fooBar);
+    }
+}
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("mc")]
+public class MyClass
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld2([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World2! " + fooBar);
+    }
+}
+""";
+        verifier.Execute(code, args: "--help", expected: """
+Usage: [command] | [arguments...] [options...] [-h|--help] [--version]
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+Commands:
+  mc
+  mc hello-world
+
+""");
+
+        verifier.Execute(code, args: "mc hello-world --help", expected: """
+Usage: hello-world [arguments...] [options...] [-h|--help] [--version]
+
+hello my world.
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+""");
+    }
 }

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -333,7 +333,7 @@ public class MyClass
 Usage: mc [command] [options...] [-h|--help] [--version]
 
 Commands:
-  hello-world
+  hello-world    hello my world.
 
 """);
         verifier.Execute(code, args: "hello-world --help", expected: """
@@ -381,7 +381,7 @@ Usage: mc [command] [options...] [-h|--help] [--version]
 My class
 
 Commands:
-  hello-world
+  hello-world    hello my world.
 
 """);
 
@@ -447,8 +447,8 @@ public class MyClass2
 Usage: [command] [options...] [-h|--help] [--version]
 
 Commands:
-  mc hello-world
-  mc2 hello-world2
+  mc hello-world     hello my world.
+  mc2 hello-world2   hello my world.
 
 """);
 
@@ -514,8 +514,8 @@ public class MyClass2
 Usage: [command] [options...] [-h|--help] [--version]
 
 Commands:
-  mc
-  mc2
+  mc    My class
+  mc2   My class 2
 
 """);
 
@@ -580,8 +580,8 @@ public class MyClass
 Usage: [command] [options...] [-h|--help] [--version]
 
 Commands:
-  mc hello-world
-  hello-world
+  hello-world      My classz
+  mc hello-world   hello my world.
 
 """);
 
@@ -653,7 +653,7 @@ Options:
   -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
 
 Commands:
-  mc hello-world
+  mc hello-world   hello my world.
 
 """);
 

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -577,7 +577,74 @@ public class MyClass
 }
 """;
         verifier.Execute(code, args: "--help", expected: """
-Usage: [command] | [arguments...] [options...] [-h|--help] [--version]
+Usage: [command] [options...] [-h|--help] [--version]
+
+Commands:
+  mc hello-world
+  hello-world
+
+""");
+
+        verifier.Execute(code, args: "mc hello-world --help", expected: """
+Usage: hello-world [arguments...] [options...] [-h|--help] [--version]
+
+hello my world.
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+""");
+    }
+
+    [Fact]
+    public void AppWithClassRootAndRootCommand()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<Root>();
+app.Add<MyClass>();
+app.Run(args);
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("")]
+public class Root
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    [Command("")]
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World! " + fooBar);
+    }
+}
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("mc")]
+public class MyClass
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld2([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World2! " + fooBar);
+    }
+}
+""";
+        verifier.Execute(code, args: "--help", expected: """
+Usage: [command] | hello-world [arguments...] [options...] [-h|--help] [--version]
 
 Arguments:
   [0] <int>    my boo is not boo.
@@ -586,7 +653,6 @@ Options:
   -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
 
 Commands:
-  mc
   mc hello-world
 
 """);

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -311,7 +311,7 @@ Options:
     {
         var code = """
 var app = ConsoleApp.Create();
-app.Add<MyClass>();
+app.Add<MyClass>("mc");
 app.Run(args);
 
 [Command("mc")]
@@ -406,7 +406,6 @@ Options:
 var app = ConsoleApp.Create();
 app.Add<MyClass>();
 app.Add<MyClass2>();
-app.SubcommandHelp(DisplayType.Default);
 app.Run(args);
 
 /// <summary>
@@ -444,16 +443,16 @@ public class MyClass2
 }
 """;
         verifier.Execute(code, args: "--help", expected: """
-Usage: [command] [options...] [-h|--help] [--version]
+Usage: [command] [-h|--help] [--version]
 
 Commands:
-  mc hello-world     hello my world.
-  mc2 hello-world2   hello my world.
+  mc hello-world      hello my world.
+  mc2 hello-world2    hello my world.
 
 """);
 
         verifier.Execute(code, args: "mc hello-world --help", expected: """
-Usage: hello-world [arguments...] [options...] [-h|--help] [--version]
+Usage: mc hello-world [arguments...] [options...] [-h|--help] [--version]
 
 hello my world.
 

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -472,7 +472,7 @@ Options:
 var app = ConsoleApp.Create();
 app.Add<MyClass>();
 app.Add<MyClass2>();
-app.SubcommandHelp(DisplayType.Hidden);
+app.SubcommandHelp(ConsoleApp.DisplayType.Hidden);
 app.Run(args);
 
 /// <summary>
@@ -515,6 +515,16 @@ Usage: [command] [options...] [-h|--help] [--version]
 Commands:
   mc    My class
   mc2   My class 2
+
+""");
+
+        verifier.Execute(code, args: "mc --help", expected: """
+Usage: mc [command] [options...] [-h|--help] [--version]
+
+My class
+
+Commands:
+  hello-world    hello my world.
 
 """);
 

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -609,6 +609,85 @@ Options:
     }
 
     [Fact]
+    public void AppWithClassWithSameCommandName()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<MyClass1>();
+app.Add<MyClass2>();
+app.Run(args);
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("mc1")]
+public class MyClass1
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World! " + fooBar);
+    }
+}
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("mc2")]
+public class MyClass2
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World2! " + fooBar);
+    }
+}
+""";
+        verifier.Execute(code, args: "--help", expected: """
+Usage: [command] [-h|--help] [--version]
+
+Commands:
+  mc1 hello-world    hello my world.
+  mc2 hello-world    hello my world.
+
+""");
+
+        verifier.Execute(code, args: "mc1 hello-world --help", expected: """
+Usage: mc1 hello-world [arguments...] [options...] [-h|--help] [--version]
+
+hello my world.
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+""");
+
+        verifier.Execute(code, args: "mc2 hello-world --help", expected: """
+Usage: mc2 hello-world [arguments...] [options...] [-h|--help] [--version]
+
+hello my world.
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+""");
+    }
+
+    [Fact]
     public void AppWithClassRootAndRootCommand()
     {
         var code = """
@@ -652,6 +731,81 @@ public class MyClass
     }
 }
 """;
+        verifier.Execute(code, args: "--help", expected: """
+Usage: [command] | hello-world [arguments...] [options...] [-h|--help] [--version]
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+Commands:
+  mc hello-world   hello my world.
+
+""");
+
+        verifier.Execute(code, args: "mc hello-world --help", expected: """
+Usage: hello-world [arguments...] [options...] [-h|--help] [--version]
+
+hello my world.
+
+Arguments:
+  [0] <int>    my boo is not boo.
+
+Options:
+  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+
+""");
+    }
+
+    [Fact]
+    public void AppWithClassRootAndRootCommandWithSameCommandName()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<Root>();
+app.Add<MyClass>();
+app.Run(args);
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("")]
+public class Root
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    [Command("")]
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World! " + fooBar);
+    }
+}
+
+/// <summary>
+/// My class
+/// </summary>
+[Command("mc")]
+public class MyClass
+{
+    /// <summary>
+    /// hello my world.
+    /// </summary>
+    /// <param name="boo">-b, my boo is not boo.</param>
+    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    public void HelloWorld([Argument]int boo, string fooBar)
+    {
+        Console.Write("Hello World2! " + fooBar);
+    }
+}
+""";
+
+        verifier.Ok(code);
+
         verifier.Execute(code, args: "--help", expected: """
 Usage: [command] | hello-world [arguments...] [options...] [-h|--help] [--version]
 

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -96,7 +96,7 @@ namespace Takoyaki
          public int Foo { get; set; }
     }
 }
-""", "--foo 10 --bar aiueo --ft Grape --flag --half 1.3 --itt 99 --obj {\"Foo\":1999}", "10aiueoGrapeTrue1.3991999");
+""", "--foo 10 --bar aiueo --ft Grape --flag --half 1.3 --itt 99 --obj {\"Foo\":1999}", "10aiueoGrapeTrue13991999");
     }
 
     [Fact]


### PR DESCRIPTION
Based on the discussion in #123. I have moved to using an app-based method to set the display of subcommands to : 
```csharp
app.SubcommandHelp(DisplayType.Default);
``` 

I want this PR to be an ongoing discussion to define all the possible cases in the test that should pass, before revising the generator. Input is very much appreciated.

I don't think it makes sense to move forward with #125 before this PR gets resolved.