### PR TITLE
fix IndexOutOfRangeException when ConsoleAppFilterAttribute is defined above CommandAttribute

### DIFF
--- a/src/ConsoleAppFramework/Parser.cs
+++ b/src/ConsoleAppFramework/Parser.cs
@@ -144,7 +144,7 @@ internal class Parser(DiagnosticReporter context, InvocationExpressionSyntax nod
                 var commandAttribute = x.GetAttributes().FirstOrDefault(x => x.AttributeClass?.Name == "CommandAttribute");
                 if (commandAttribute != null)
                 {
-                    commandName = (x.GetAttributes()[0].ConstructorArguments[0].Value as string)!;
+                    commandName = (commandAttribute.ConstructorArguments[0].Value as string)!;
                 }
                 else
                 {

--- a/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppBuilderTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppBuilderTest.cs
@@ -241,7 +241,46 @@ public class MyClass()
 
         verifier.Execute(code, "nomunomu", "yeah");
     }
+
+ [Fact]
+    public void CommandAttrWithFilter()
+    {
+        var code = """
+var builder = ConsoleApp.Create();
+builder.Add<MyClass>();
+builder.Run(args);
+
+public class MyClass()
+{
+    [ConsoleAppFilter<NopFilter1>]
+    [Command("nomunomu")]
+    [ConsoleAppFilter<NopFilter2>]
+    public void Do()
+    {
+        Console.Write("command");
+    }
 }
 
+internal class NopFilter1(ConsoleAppFilter next)
+    : ConsoleAppFilter(next)
+{
+    public override Task InvokeAsync(ConsoleAppContext context,CancellationToken cancellationToken)
+    {
+        Console.Write("filter1-");
+        return Next.InvokeAsync(context, cancellationToken);
+    }
+}
+internal class NopFilter2(ConsoleAppFilter next)
+    : ConsoleAppFilter(next)
+{
+    public override Task InvokeAsync(ConsoleAppContext context,CancellationToken cancellationToken)
+    {
+        Console.Write("filter2-");
+        return Next.InvokeAsync(context, cancellationToken);
+    }
+}
+""";
 
-
+        verifier.Execute(code, "nomunomu", "filter1-filter2-command");
+    }
+}


### PR DESCRIPTION
fix for #134.
The cause of this issue was that we were referencing the first element of the attribute list (GetAttributes()[0]) when retrieving the command name.

Please review the code changes.