### PR TITLE
Fix commas being stripped from helptext

### DIFF
--- a/src/ConsoleAppFramework/Parser.cs
+++ b/src/ConsoleAppFramework/Parser.cs
@@ -591,13 +591,13 @@ internal class Parser(DiagnosticReporter context, InvocationExpressionSyntax nod
         // Example:
         // -h|--help, This is a help.
 
-        var splitOne = originalDescription.Split(',');
+        var splitOne = originalDescription.Split(',', 2);
 
         // has alias
         if (splitOne[0].TrimStart().StartsWith("-"))
         {
             aliases = splitOne[0].Split(['|'], StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToArray();
-            description = string.Join("", splitOne.Skip(1)).Trim();
+            description = splitOne[1].Trim();
         }
         else
         {

--- a/src/ConsoleAppFramework/Parser.cs
+++ b/src/ConsoleAppFramework/Parser.cs
@@ -597,7 +597,7 @@ internal class Parser(DiagnosticReporter context, InvocationExpressionSyntax nod
         if (splitOne[0].TrimStart().StartsWith("-"))
         {
             aliases = splitOne[0].Split(['|'], StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToArray();
-            description = splitOne[1].Trim();
+            description = splitOne.Length > 1 ? splitOne[1].Trim() : string.Empty;
         }
         else
         {

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -285,7 +285,7 @@ public class MyClass
     /// hello my world.
     /// </summary>
     /// <param name="boo">-b, my boo is not boo.</param>
-    /// <param name="fooBar">-f|-fb, my foo is not bar.</param>
+    /// <param name="fooBar">-f|-fb, my foo, is not bar.</param>
     public void HelloWorld([Argument]int boo, string fooBar)
     {
         Console.Write("Hello World! " + fooBar);
@@ -301,7 +301,7 @@ Arguments:
   [0] <int>    my boo is not boo.
 
 Options:
-  -f|-fb|--foo-bar <string>    my foo is not bar. (Required)
+  -f|-fb|--foo-bar <string>    my foo, is not bar. (Required)
 
 """);
     }


### PR DESCRIPTION
Our 
```cs
<param name="param_name">-p, Param description, example: "a,b,c".</param>
```

Was being converted to
```
Param description example: "abc".
```
on the helptext output.