### PR TITLE
Remove FluentAssertions, Use Shouldly

### DIFF
--- a/tests/ConsoleAppFramework.GeneratorTests/CSharpGeneratorRunner.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/CSharpGeneratorRunner.cs
@@ -153,7 +153,7 @@ public class VerifyHelper(ITestOutputHelper output, string idPrefix)
         }
         OutputGeneratedCode(compilation);
 
-        diagnostics.Length.Should().Be(0);
+        diagnostics.Length.ShouldBe(0);
     }
 
     public void Verify(int id, [StringSyntax("C#-test")] string code, string diagnosticsCodeSpan, [CallerArgumentExpression("code")] string? codeExpr = null)
@@ -167,11 +167,11 @@ public class VerifyHelper(ITestOutputHelper output, string idPrefix)
         }
         OutputGeneratedCode(compilation);
 
-        diagnostics.Length.Should().Be(1);
-        diagnostics[0].Id.Should().Be(idPrefix + id.ToString("000"));
+        diagnostics.Length.ShouldBe(1);
+        diagnostics[0].Id.ShouldBe(idPrefix + id.ToString("000"));
 
         var text = GetLocationText(diagnostics[0], compilation.SyntaxTrees);
-        text.Should().Be(diagnosticsCodeSpan);
+        text.ShouldBe(diagnosticsCodeSpan);
     }
 
     public (string, string)[] Verify([StringSyntax("C#-test")] string code, [CallerArgumentExpression("code")] string? codeExpr = null)
@@ -196,7 +196,7 @@ public class VerifyHelper(ITestOutputHelper output, string idPrefix)
         }
         OutputGeneratedCode(compilation);
 
-        stdout.Should().Be(expected);
+        stdout.ShouldBe(expected);
     }
 
     public string Error([StringSyntax("C#-test")] string code, string args, [CallerArgumentExpression("code")] string? codeExpr = null)

--- a/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppBuilderTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppBuilderTest.cs
@@ -27,9 +27,9 @@ builder.Run(args);
         verifier.Execute(code, "foo --x 10 --y 20", "30");
         verifier.Execute(code, "bar --x 20 --y 30", "50");
         verifier.Execute(code, "bar --x 20", "30");
-        Environment.ExitCode.Should().Be(0);
+        Environment.ExitCode.ShouldBe(0);
         verifier.Execute(code, "baz --x 40 --y takoyaki", "40takoyaki");
-        Environment.ExitCode.Should().Be(10);
+        Environment.ExitCode.ShouldBe(10);
         Environment.ExitCode = 0;
 
         verifier.Execute(code, "boz --x 40", "80");
@@ -50,9 +50,9 @@ await builder.RunAsync(args);
         verifier.Execute(code, "foo --x 10 --y 20", "30");
         verifier.Execute(code, "bar --x 20 --y 30", "50");
         verifier.Execute(code, "bar --x 20", "30");
-        Environment.ExitCode.Should().Be(0);
+        Environment.ExitCode.ShouldBe(0);
         verifier.Execute(code, "baz --x 40 --y takoyaki", "40takoyaki");
-        Environment.ExitCode.Should().Be(10);
+        Environment.ExitCode.ShouldBe(10);
         Environment.ExitCode = 0;
 
         verifier.Execute(code, "boz --x 40", "80");

--- a/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppFramework.GeneratorTests.csproj
+++ b/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppFramework.GeneratorTests.csproj
@@ -4,15 +4,13 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<Configurations>Debug;Release</Configurations>
 	</PropertyGroup>
 
-	
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Shouldly" Version="4.2.1" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
 		<PackageReference Include="xunit" Version="2.4.2" />
@@ -26,4 +24,9 @@
 		<ProjectReference Include="..\..\src\ConsoleAppFramework\ConsoleAppFramework.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<Using Include="Xunit" />
+		<Using Include="Xunit.Abstractions" />
+		<Using Include="Shouldly" />
+	</ItemGroup>
 </Project>

--- a/tests/ConsoleAppFramework.GeneratorTests/GlobalUsings.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/GlobalUsings.cs
@@ -1,7 +1,3 @@
-global using Xunit;
-global using Xunit.Abstractions;
-global using FluentAssertions;
-
 // CSharpGeneratorRunner.CompileAndExecute uses stdout hook(replace Console.Out)
 // so can not work in parallel test
 [assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/ConsoleAppFramework.GeneratorTests/IncrementalGeneratorTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/IncrementalGeneratorTest.cs
@@ -13,13 +13,13 @@ public class IncrementalGeneratorTest
     void VerifySourceOutputReasonIsCached((string Key, string Reasons)[] reasons)
     {
         var reason = reasons.FirstOrDefault(x => x.Key == "SourceOutput").Reasons;
-        reason.Should().Be("Cached");
+        reason.ShouldBe("Cached");
     }
 
     void VerifySourceOutputReasonIsNotCached((string Key, string Reasons)[] reasons)
     {
         var reason = reasons.FirstOrDefault(x => x.Key == "SourceOutput").Reasons;
-        reason.Should().NotBe("Cached");
+        reason.ShouldNotBe("Cached");
     }
 
     [Fact]
@@ -49,9 +49,9 @@ Console.WriteLine("foo"); // unrelated line
 
         var reasons = CSharpGeneratorRunner.GetIncrementalGeneratorTrackedStepsReasons("ConsoleApp.Run.", step1, step2, step3);
 
-        reasons[0][0].Reasons.Should().Be("New");
-        reasons[1][0].Reasons.Should().Be("Unchanged");
-        reasons[2][0].Reasons.Should().Be("Modified");
+        reasons[0][0].Reasons.ShouldBe("New");
+        reasons[1][0].Reasons.ShouldBe("Unchanged");
+        reasons[2][0].Reasons.ShouldBe("Modified");
 
         VerifySourceOutputReasonIsCached(reasons[1]);
         VerifySourceOutputReasonIsNotCached(reasons[2]);
@@ -116,9 +116,9 @@ public class Tako
 
         var reasons = CSharpGeneratorRunner.GetIncrementalGeneratorTrackedStepsReasons("ConsoleApp.Run.", step1, step2, step3);
 
-        reasons[0][0].Reasons.Should().Be("New");
-        reasons[1][0].Reasons.Should().Be("Unchanged");
-        reasons[2][0].Reasons.Should().Be("Modified");
+        reasons[0][0].Reasons.ShouldBe("New");
+        reasons[1][0].Reasons.ShouldBe("Unchanged");
+        reasons[2][0].Reasons.ShouldBe("Modified");
 
         VerifySourceOutputReasonIsCached(reasons[1]);
     }
@@ -171,9 +171,9 @@ static void DoHello(int x, int y) // change signature
 
         var reasons = CSharpGeneratorRunner.GetIncrementalGeneratorTrackedStepsReasons("ConsoleApp.Run.", step1, step2, step3);
 
-        reasons[0][0].Reasons.Should().Be("New");
-        reasons[1][0].Reasons.Should().Be("Unchanged");
-        reasons[2][0].Reasons.Should().Be("Modified");
+        reasons[0][0].Reasons.ShouldBe("New");
+        reasons[1][0].Reasons.ShouldBe("Unchanged");
+        reasons[2][0].Reasons.ShouldBe("Modified");
 
         VerifySourceOutputReasonIsCached(reasons[1]);
     }

--- a/tests/ConsoleAppFramework.GeneratorTests/NameConverterTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/NameConverterTest.cs
@@ -14,19 +14,19 @@ public class NameConverterTest(ITestOutputHelper output)
     [Fact]
     public void KebabCase()
     {
-        NameConverter.ToKebabCase("").Should().Be("");
-        NameConverter.ToKebabCase("HelloWorld").Should().Be("hello-world");
-        NameConverter.ToKebabCase("HelloWorldMyHome").Should().Be("hello-world-my-home");
-        NameConverter.ToKebabCase("helloWorld").Should().Be("hello-world");
-        NameConverter.ToKebabCase("hello-world").Should().Be("hello-world");
-        NameConverter.ToKebabCase("A").Should().Be("a");
-        NameConverter.ToKebabCase("AB").Should().Be("ab");
-        NameConverter.ToKebabCase("ABC").Should().Be("abc");
-        NameConverter.ToKebabCase("ABCD").Should().Be("abcd");
-        NameConverter.ToKebabCase("ABCDeF").Should().Be("abc-def");
-        NameConverter.ToKebabCase("XmlReader").Should().Be("xml-reader");
-        NameConverter.ToKebabCase("XMLReader").Should().Be("xml-reader");
-        NameConverter.ToKebabCase("MLLibrary").Should().Be("ml-library");
+        NameConverter.ToKebabCase("").ShouldBe("");
+        NameConverter.ToKebabCase("HelloWorld").ShouldBe("hello-world");
+        NameConverter.ToKebabCase("HelloWorldMyHome").ShouldBe("hello-world-my-home");
+        NameConverter.ToKebabCase("helloWorld").ShouldBe("hello-world");
+        NameConverter.ToKebabCase("hello-world").ShouldBe("hello-world");
+        NameConverter.ToKebabCase("A").ShouldBe("a");
+        NameConverter.ToKebabCase("AB").ShouldBe("ab");
+        NameConverter.ToKebabCase("ABC").ShouldBe("abc");
+        NameConverter.ToKebabCase("ABCD").ShouldBe("abcd");
+        NameConverter.ToKebabCase("ABCDeF").ShouldBe("abc-def");
+        NameConverter.ToKebabCase("XmlReader").ShouldBe("xml-reader");
+        NameConverter.ToKebabCase("XMLReader").ShouldBe("xml-reader");
+        NameConverter.ToKebabCase("MLLibrary").ShouldBe("ml-library");
     }
 
     [Fact]

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -23,15 +22,15 @@ public class Test(ITestOutputHelper output)
     [Fact]
     public void SyncRunShouldFailed()
     {
-        verifier.Error("ConsoleApp.Run(args, (int x) => { Console.Write((x)); });", "--x").Should().Contain("Argument 'x' failed to parse");
+        verifier.Error("ConsoleApp.Run(args, (int x) => { Console.Write((x)); });", "--x").ShouldContain("Argument 'x' failed to parse");
     }
 
     [Fact]
     public void MissingArgument()
     {
-        verifier.Error("ConsoleApp.Run(args, (int x, int y) => { Console.Write((x + y)); });", "--x 10 y 20").Should().Contain("Argument 'y' is not recognized.");
+        verifier.Error("ConsoleApp.Run(args, (int x, int y) => { Console.Write((x + y)); });", "--x 10 y 20").ShouldContain("Argument 'y' is not recognized.");
 
-        Environment.ExitCode.Should().Be(1);
+        Environment.ExitCode.ShouldBe(1);
         Environment.ExitCode = 0;
     }
 
@@ -48,7 +47,7 @@ The field x must be between 1 and 10.
 ConsoleApp.Run(args, ([Range(1, 10)]int x, [Range(100, 200)]int y) => { Console.Write((x + y)); });
 """, "--x 100 --y 140", expected);
 
-        Environment.ExitCode.Should().Be(1);
+        Environment.ExitCode.ShouldBe(1);
         Environment.ExitCode = 0;
     }
 
@@ -66,7 +65,7 @@ The field y must be between 100 and 200.
 ConsoleApp.Run(args, ([Range(1, 10)]int x, [Range(100, 200)]int y) => { Console.Write((x + y)); });
 """, "--x 100 --y 240", expected);
 
-        Environment.ExitCode.Should().Be(1);
+        Environment.ExitCode.ShouldBe(1);
         Environment.ExitCode = 0;
     }
     [Fact]


### PR DESCRIPTION
`FluentAssertions` has been acquired and changed to a commercial license.
https://github.com/fluentassertions/fluentassertions/pull/2943
Such an abrupt license change from OSS is unacceptable.
I removed `FluentAssertions` and switched to [Shouldly](https://github.com/shouldly/shouldly), which provides equivalent functionality.