### PR TITLE
chore: Update benchmarks

### DIFF
--- a/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
+++ b/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
@@ -15,7 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
 		<PackageReference Include="CliFx" Version="2.3.5" />
 		<PackageReference Include="clipr" Version="1.6.1" />
 		<PackageReference Include="Cocona" Version="2.2.0" />
@@ -26,7 +26,8 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
 		<PackageReference Include="PowerArgs" Version="4.0.3" />
 		<PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
-		<PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20071.2" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+		<PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
 	</ItemGroup>
 
 

--- a/sandbox/CliFrameworkBenchmark/Commands/SystemCommandLineCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/SystemCommandLineCommand.cs
@@ -1,5 +1,5 @@
 using System.CommandLine;
-using System.CommandLine.Invocation;
+using System.CommandLine.NamingConventionBinder;
 
 namespace Cocona.Benchmark.External.Commands;
 
@@ -11,18 +11,9 @@ public class SystemCommandLineCommand
     {
         var command = new RootCommand
         {
-            new Option(new[] {"--str", "-s"})
-            {
-                Argument = new Argument<string?>()
-            },
-            new Option(new[] {"--int", "-i"})
-            {
-                Argument = new Argument<int>()
-            },
-            new Option(new[] {"--bool", "-b"})
-            {
-                Argument = new Argument<bool>()
-            }
+            new Option<string?>(new[] {"--str", "-s"}),
+            new Option<int>(new[] {"--int", "-i"}),
+            new Option<bool>(new[] {"--bool", "-b"}),
         };
 
         command.Handler = CommandHandler.Create(ExecuteHandler);
@@ -33,18 +24,9 @@ public class SystemCommandLineCommand
     {
         var command = new RootCommand
         {
-            new Option(new[] {"--str", "-s"})
-            {
-                Argument = new Argument<string?>()
-            },
-            new Option(new[] {"--int", "-i"})
-            {
-                Argument = new Argument<int>()
-            },
-            new Option(new[] {"--bool", "-b"})
-            {
-                Argument = new Argument<bool>()
-            }
+            new Option<string?>(new[] {"--str", "-s"}),
+            new Option<int>(new[] {"--int", "-i"}),
+            new Option<bool>(new[] {"--bool", "-b"}),
         };
 
         command.Handler = CommandHandler.Create(ExecuteHandler);

--- a/sandbox/CliFrameworkBenchmark/Program.cs
+++ b/sandbox/CliFrameworkBenchmark/Program.cs
@@ -12,6 +12,6 @@ class Program
 {
     static void Main(string[] args)
     {
-        BenchmarkRunner.Run<Benchmark>(DefaultConfig.Instance.WithSummaryStyle(SummaryStyle.Default.WithTimeUnit(TimeUnit.Millisecond)));
+        BenchmarkRunner.Run<Benchmark>(DefaultConfig.Instance.WithSummaryStyle(SummaryStyle.Default.WithTimeUnit(TimeUnit.Millisecond)), args);
     }
 }

--- a/sandbox/CliFrameworkBenchmark/Properties/launchSettings.json
+++ b/sandbox/CliFrameworkBenchmark/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Default": {
+      "commandName": "Project",
+      "commandLineArgs": ""
+    },
+    "Measure": {
+      "commandName": "Project",
+      "commandLineArgs": "--launchCount 20"
+    }
+  }
+}


### PR DESCRIPTION
**What's included in this PR**

1. Update `BenchmarkDotNet` package to latest version
2. Update `System.CommandLine` from `beta1` to `beta4`
3. Modify `Program.cs`  and add `launchSettings.json` for measuring **average** cold startup time

**Benchmark results**

>dotnet run -c Release -- --launchCount 20

Method                   | Mean       | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------------- |-----------:|----------:|----------:|------:|--------:|----------:|------------:|
| 'ConsoleAppFramework v5' |   1.558 ms | 0.1154 ms | 0.1329 ms |  1.01 |    0.11 |     400 B |        1.00 |
| CliFx                    |  24.850 ms | 0.5209 ms | 0.5999 ms | 16.04 |    1.25 |   57640 B |      144.10 |
| System.CommandLine       |  29.528 ms | 3.3015 ms | 3.8020 ms | 19.07 |    2.79 |   18720 B |       46.80 |
| Cocona.Lite              |  47.108 ms | 0.8073 ms | 0.9297 ms | 30.42 |    2.34 |   59784 B |      149.46 |
| Spectre.Console.Cli      |  54.705 ms | 0.8616 ms | 0.9922 ms | 35.32 |    2.70 |   65680 B |      164.20 |
| Cocona                   | 134.436 ms | 1.5971 ms | 1.8392 ms | 86.80 |    6.56 |  461640 B |    1,154.10 |

It seems `System.CommandLine` performance is significantly improved.