### PR TITLE
fix: Tests failed when line-end characters differ from OS default

### DIFF
--- a/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
+++ b/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
@@ -8,7 +8,7 @@ public static class ConsoleAppBaseCode
 #pragma warning disable
 
 namespace ConsoleAppFramework;
-        
+
 using System;
 using System.Text;
 using System.Reflection;
@@ -307,7 +307,7 @@ internal static partial class ConsoleApp
         if (args.Length == 0)
         {
             if (requiredParameterCount == 0) return false;
-            
+
             ShowHelp(helpId);
             return true;
         }
@@ -531,7 +531,7 @@ internal static partial class ConsoleApp
             if (args.Length == 0)
             {
                 if (requiredParameterCount == 0) return false;
-            
+
                 ShowHelp(helpId);
                 return true;
             }

--- a/tests/ConsoleAppFramework.GeneratorTests/CSharpGeneratorRunner.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/CSharpGeneratorRunner.cs
@@ -196,7 +196,7 @@ public class VerifyHelper(ITestOutputHelper output, string idPrefix)
         }
         OutputGeneratedCode(compilation);
 
-        stdout.ShouldBe(expected);
+        stdout.ShouldBe(expected, StringCompareShould.IgnoreLineEndings);
     }
 
     public string Error([StringSyntax("C#-test")] string code, string args, [CallerArgumentExpression("code")] string? codeExpr = null)


### PR DESCRIPTION
This PR intended to fix part of issue #162.
By ignoring line ending difference with `StringCompareShould.IgnoreLineEndings` option.

Additionally, I've removed extra spaces from source generation code 