### PR TITLE
Update tests related projects

### DIFF
--- a/ConsoleAppFramework.sln
+++ b/ConsoleAppFramework.sln
@@ -8,6 +8,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sandbox", "sandbox", "{A2CF2984-E8E2-48FC-B5A1-58D74A2467E6}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{AAD2D900-C305-4449-A9FC-6C7696FFEDFA}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6DF6534A-0F9D-44A4-BF89-AE1F3B243914}"
 	ProjectSection(SolutionItems) = preProject

--- a/sandbox/GeneratorSandbox/Program.cs
+++ b/sandbox/GeneratorSandbox/Program.cs
@@ -31,8 +31,8 @@ using System.Text.Json;
 //        services.Configure<PositionOptions>(configuration.GetSection("Position"));
 //    });
 
-
-args = ["run", "--project", "foo.csproj", "--", "--foo", "100", "--bar", "bazbaz"];
+//// Uncomment following line to overwrite args.
+// args = ["run", "--project", "foo.csproj", "--", "--foo", "100", "--bar", "bazbaz"];
 
 // dotnet run --project foo.csproj -- --foo 100 --bar bazbaz
 

--- a/sandbox/GeneratorSandbox/Properties/launchSettings.json
+++ b/sandbox/GeneratorSandbox/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "Default": {
+      "commandName": "Project",
+      "commandLineArgs": "run --project foo.csproj -- --foo 100 --bar bazbaz"
+    },
+    "ShowVersion": {
+      "commandName": "Project",
+      "commandLineArgs": "--version"
+    },
+    "ShowRootCommandHelp": {
+      "commandName": "Project",
+      "commandLineArgs": "--help"
+    },
+    "ShowRunCommandHelp": {
+      "commandName": "Project",
+      "commandLineArgs": "run --help"
+    }
+  }
+}

--- a/tests/ConsoleAppFramework.GeneratorTests/ArrayParseTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/ArrayParseTest.cs
@@ -1,5 +1,3 @@
-using Xunit.Abstractions;
-
 namespace ConsoleAppFramework.GeneratorTests
 {
     public class ArrayParseTest(ITestOutputHelper output)

--- a/tests/ConsoleAppFramework.GeneratorTests/CSharpGeneratorRunner.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/CSharpGeneratorRunner.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
-using Xunit.Abstractions;
 
 public static class CSharpGeneratorRunner
 {
@@ -144,7 +143,7 @@ public class VerifyHelper(ITestOutputHelper output, string idPrefix)
 
     public void Ok([StringSyntax("C#-test")] string code, [CallerArgumentExpression("code")] string? codeExpr = null)
     {
-        output.WriteLine(codeExpr);
+        output.WriteLine(codeExpr!);
 
         var (compilation, diagnostics) = CSharpGeneratorRunner.RunGenerator(code);
         foreach (var item in diagnostics)
@@ -158,7 +157,7 @@ public class VerifyHelper(ITestOutputHelper output, string idPrefix)
 
     public void Verify(int id, [StringSyntax("C#-test")] string code, string diagnosticsCodeSpan, [CallerArgumentExpression("code")] string? codeExpr = null)
     {
-        output.WriteLine(codeExpr);
+        output.WriteLine(codeExpr!);
 
         var (compilation, diagnostics) = CSharpGeneratorRunner.RunGenerator(code);
         foreach (var item in diagnostics)
@@ -176,7 +175,7 @@ public class VerifyHelper(ITestOutputHelper output, string idPrefix)
 
     public (string, string)[] Verify([StringSyntax("C#-test")] string code, [CallerArgumentExpression("code")] string? codeExpr = null)
     {
-        output.WriteLine(codeExpr);
+        output.WriteLine(codeExpr!);
 
         var (compilation, diagnostics) = CSharpGeneratorRunner.RunGenerator(code);
         OutputGeneratedCode(compilation);
@@ -187,7 +186,7 @@ public class VerifyHelper(ITestOutputHelper output, string idPrefix)
 
     public void Execute([StringSyntax("C#-test")] string code, string args, string expected, [CallerArgumentExpression("code")] string? codeExpr = null)
     {
-        output.WriteLine(codeExpr);
+        output.WriteLine(codeExpr!);
 
         var (compilation, diagnostics, stdout) = CSharpGeneratorRunner.CompileAndExecute(code, args == "" ? [] : args.Split(' '));
         foreach (var item in diagnostics)
@@ -201,7 +200,7 @@ public class VerifyHelper(ITestOutputHelper output, string idPrefix)
 
     public string Error([StringSyntax("C#-test")] string code, string args, [CallerArgumentExpression("code")] string? codeExpr = null)
     {
-        output.WriteLine(codeExpr);
+        output.WriteLine(codeExpr!);
 
         var (compilation, diagnostics, stdout) = CSharpGeneratorRunner.CompileAndExecute(code, args == "" ? [] : args.Split(' '));
         foreach (var item in diagnostics)

--- a/tests/ConsoleAppFramework.GeneratorTests/CSharpGeneratorRunner.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/CSharpGeneratorRunner.cs
@@ -24,7 +24,13 @@ global using ConsoleAppFramework;
 
         var references = AppDomain.CurrentDomain.GetAssemblies()
             .Where(x => !x.IsDynamic && !string.IsNullOrWhiteSpace(x.Location))
-            .Select(x => MetadataReference.CreateFromFile(x.Location));
+            .Select(x => MetadataReference.CreateFromFile(x.Location))
+            .Concat([
+                MetadataReference.CreateFromFile(typeof(Console).Assembly.Location),                                                 // System.Console.dll
+                MetadataReference.CreateFromFile(typeof(IServiceProvider).Assembly.Location),                                        // System.ComponentModel.dll
+                MetadataReference.CreateFromFile(typeof(System.ComponentModel.DataAnnotations.RequiredAttribute).Assembly.Location), // System.ComponentModel.DataAnnotations
+                MetadataReference.CreateFromFile(typeof(System.Text.Json.JsonDocument).Assembly.Location),                           // System.Text.Json.dll
+            ]);
 
         var compilation = CSharpCompilation.Create("generatortest",
             references: references,

--- a/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppBuilderTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppBuilderTest.cs
@@ -1,11 +1,3 @@
-using Microsoft.VisualStudio.TestPlatform.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit.Abstractions;
-
 namespace ConsoleAppFramework.GeneratorTests;
 
 public class ConsoleAppBuilderTest(ITestOutputHelper output)

--- a/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppBuilderTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppBuilderTest.cs
@@ -1,8 +1,10 @@
 namespace ConsoleAppFramework.GeneratorTests;
 
-public class ConsoleAppBuilderTest(ITestOutputHelper output)
+public class ConsoleAppBuilderTest(ITestOutputHelper output) : IDisposable
 {
     VerifyHelper verifier = new VerifyHelper(output, "CAF");
+
+    public void Dispose() => Environment.ExitCode = 0;
 
     [Fact]
     public void BuilderRun()

--- a/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppFramework.GeneratorTests.csproj
+++ b/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppFramework.GeneratorTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shouldly" Version="4.2.1" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -26,7 +27,6 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="Xunit.Abstractions" />
     <Using Include="Shouldly" />
   </ItemGroup>
 </Project>

--- a/tests/ConsoleAppFramework.GeneratorTests/DiagnosticsTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/DiagnosticsTest.cs
@@ -1,5 +1,3 @@
-using Xunit.Abstractions;
-
 namespace ConsoleAppFramework.GeneratorTests;
 
 public class DiagnosticsTest(ITestOutputHelper output)

--- a/tests/ConsoleAppFramework.GeneratorTests/FilterTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/FilterTest.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit.Abstractions;
-
 namespace ConsoleAppFramework.GeneratorTests;
 
 public class FilterTest(ITestOutputHelper output)

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Xunit.Abstractions;
 
 namespace ConsoleAppFramework.GeneratorTests;
 

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -14,7 +14,7 @@ public class HelpTest(ITestOutputHelper output)
     [Fact]
     public void Version()
     {
-        var version = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "1.0.0";
+        var version = GetEntryAssemblyVersion();
 
         verifier.Execute(code: $$"""
 ConsoleApp.Run(args, (int x, int y) => { });
@@ -39,7 +39,7 @@ ConsoleApp.Run(args, (int x, int y) => { });
     [Fact]
     public void VersionOnBuilder()
     {
-        var version = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "1.0.0";
+        var version = GetEntryAssemblyVersion();
 
         verifier.Execute(code: """
 var app = ConsoleApp.Create();
@@ -319,5 +319,22 @@ Options:
   -f|-fb|--foo-bar <string>    my foo, is not bar. (Required)
 
 """);
+    }
+
+    private static string GetEntryAssemblyVersion()
+    {
+        var version = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        if (version == null)
+            return "1.0.0";
+
+        // Trim SourceRevisionId (SourceLink feature is enabled by default when using .NET SDK 8 or later)
+        var i = version.IndexOf('+');
+        if (i != -1)
+        {
+            version = version.Substring(0, i);
+        }
+
+        return version;
     }
 }

--- a/tests/ConsoleAppFramework.GeneratorTests/NameConverterTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/NameConverterTest.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit.Abstractions;
-
 namespace ConsoleAppFramework.GeneratorTests;
 
 public class NameConverterTest(ITestOutputHelper output)

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -1,12 +1,3 @@
-using Microsoft.CodeAnalysis;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit.Abstractions;
-
 namespace ConsoleAppFramework.GeneratorTests;
 
 public class Test(ITestOutputHelper output)

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -1,8 +1,10 @@
 namespace ConsoleAppFramework.GeneratorTests;
 
-public class Test(ITestOutputHelper output)
+public class Test(ITestOutputHelper output) : IDisposable
 {
     VerifyHelper verifier = new VerifyHelper(output, "CAF");
+
+    public void Dispose() => Environment.ExitCode = 0;
 
     [Fact]
     public void SyncRun()

--- a/tests/ConsoleAppFramework.GeneratorTests/SubCommandTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/SubCommandTest.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit.Abstractions;
-
 namespace ConsoleAppFramework.GeneratorTests;
 
 public class SubCommandTest(ITestOutputHelper output)

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,25 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('$(MSBuildThisFile)', '$(MSBuildThisFileDirectory)../'))" />
+
+  <PropertyGroup>
+    <!-- Enable Microsoft.Testing.Platform -->
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+
+    <!-- Use Microsoft.Testing.Platform exe entry point instead of xUnit.net -->
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+    <!-- Output all output logs to console -->
+    <TestingPlatformCaptureOutput>false</TestingPlatformCaptureOutput>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Show xUnit.net headers and information -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --xunit-info</TestingPlatformCommandLineArguments>
+
+    <!-- Set TestResults output directory -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --results-directory "$(MSBuildThisFileDirectory)TestResults"</TestingPlatformCommandLineArguments>
+
+    <!-- Ignore exit code 8 (the test session run zero tests) -->
+    <TestingPlatformCommandLineArguments>$(TestingPlatformCommandLineArguments) --ignore-exit-code 8</TestingPlatformCommandLineArguments>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
This PR intended to update xUnit version to latest v3.
And switch test runner to use  `Microsoft.Testing.Platform` based runner instead of VSTest.

### What's changed in this PR.

#### 1. Update test projects to use xUnit.v3 (52478721e7b6d97e9a085e41e71fe53fee82895c)
- 1.1. Update following NuGet packages and fix build errors.
  - Shouldly
  - Microsoft.NET.Test.Sdk
  - xunit -> xunit.v3
  - xunit.runner.visualstudio
- 1.2. Fix build errors/warnings. 

#### 2. Fix test code (0259c36f37fcd77b1a6348e2a566064b0bf20fb8)

- 2.1. Add `tests\Directory.Build.props` file and add setting to use `Microsoft.Testing.Platform`
- 2.2. Modify `CSharpGeneratorRunner.cs` and add additional DLL references. 
         (It's seems be required when using `xunit.runner.visualstudio` v2.5.0 or later) 
- 2.3. Implement `IDisposable` interface on some class and clear `Environment.ExitCode` on every test run finished. 
- 2.4. Modify assembly version check logics at `HelpTest.cs`

#### 3. Modify GeneratorSandbox project launch settings (c4a86c0ec035c328c3d9848bdee37cc98df135e3)



