### PR TITLE
feat: Add HiddenAttribute to hide specific command/parameter

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -697,6 +697,13 @@ The field secondArg must be between 0 and 2.
 
 By default, the ExitCode is set to 1 in this case.
 
+Hide command/parameter help
+---
+`ConsoleAppFramework` supports `HiddenAttribute` which is used to hide specific help for a command/parameter.
+
+- When`HiddenAttribute` is set to command, it hides command from command list.
+- When`HiddenAttribute` is set to parameter, it hides parameter from command help.
+
 Filter(Middleware) Pipeline / ConsoleAppContext
 ---
 Filters are provided as a mechanism to hook into the execution before and after. To use filters, define an `internal class` that implements `ConsoleAppFilter`.

--- a/src/ConsoleAppFramework/Command.cs
+++ b/src/ConsoleAppFramework/Command.cs
@@ -18,6 +18,7 @@ public record class Command
 {
     public required bool IsAsync { get; init; } // Task or Task<int>
     public required bool IsVoid { get; init; }  // void or int
+    public required bool IsHidden { get; init; } // Hide help from command list
 
     public bool IsRootCommand => Name == "";
     public required string Name { get; init; }
@@ -153,6 +154,7 @@ public record class CommandParameter
     public required IgnoreEquality<WellKnownTypes> WellKnownTypes { get; init; }
     public required bool IsNullableReference { get; init; }
     public required bool IsParams { get; init; }
+    public required bool IsHidden { get; init; } // Hide command parameter help
     public required string Name { get; init; }
     public required string OriginalParameterName { get; init; }
     public required bool HasDefaultValue { get; init; }

--- a/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
+++ b/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
@@ -122,6 +122,11 @@ internal sealed class CommandAttribute : Attribute
     }
 }
 
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+internal sealed class HiddenAttribute : Attribute
+{
+}
+
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
 internal sealed class RegisterCommandsAttribute : Attribute
 {

--- a/tests/ConsoleAppFramework.GeneratorTests/HiddenAttributeTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HiddenAttributeTest.cs
@@ -1,0 +1,121 @@
+namespace ConsoleAppFramework.GeneratorTests;
+
+public class HiddenAtttributeTest(ITestOutputHelper output)
+{
+    VerifyHelper verifier = new(output, "CAF");
+
+    [Fact]
+    public void VerifyHiddenOptions_Lambda()
+    {
+        var code =
+            """
+            ConsoleApp.Run(args, (int x, [Hidden]int y) => { });
+            """;
+
+        // Verify Hidden options is not shown on command help.
+        verifier.Execute(code, args: "--help", expected:
+            """
+            Usage: [options...] [-h|--help] [--version]
+
+            Options:
+              --x <int>     (Required)
+
+            """);
+    }
+
+    [Fact]
+    public void VerifyHiddenCommands_Class()
+    {
+        var code =
+            """
+            var builder = ConsoleApp.Create();
+            builder.Add<Commands>();
+            await builder.RunAsync(args);
+
+            public class Commands
+            {
+                [Hidden]
+                public void Command1() { Console.Write("command1"); }
+
+                public void Command2() { Console.Write("command2"); }
+
+                [Hidden]
+                public void Command3(int x, [Hidden]int y) { Console.Write($"command3: x={x} y={y}"); }
+            }
+            """;
+
+        // Verify hidden command is not shown on root help commands.
+        verifier.Execute(code, args: "--help", expected:
+            """
+            Usage: [command] [-h|--help] [--version]
+
+            Commands:
+              command2
+
+            """);
+
+        // Verify Hidden command help is shown when explicitly specify command name.
+        verifier.Execute(code, args: "command1 --help", expected:
+            """
+            Usage: command1 [-h|--help] [--version]
+            
+            """);
+
+        verifier.Execute(code, args: "command2 --help", expected:
+            """
+            Usage: command2 [-h|--help] [--version]
+
+            """);
+
+        verifier.Execute(code, args: "command3 --help", expected:
+            """
+            Usage: command3 [options...] [-h|--help] [--version]
+
+            Options:
+              --x <int>     (Required)
+
+            """);
+
+        // Verify commands involations
+        verifier.Execute(code, args: "command1", "command1");
+        verifier.Execute(code, args: "command2", "command2");
+        verifier.Execute(code, args: "command3 --x 1 --y 2", expected: "command3: x=1 y=2");
+    }
+
+    [Fact]
+    public void VerifyHiddenCommands_LocalFunctions()
+    {
+        var code =
+            """
+                var builder = ConsoleApp.Create();
+            
+                builder.Add("", () => { Console.Write("root"); });
+                builder.Add("command1", Command1);
+                builder.Add("command2", Command2);
+                builder.Add("command3", Command3);
+                builder.Run(args);
+
+                [Hidden]
+                static void Command1() { Console.Write("command1"); }
+
+                static void Command2() { Console.Write("command2"); }
+
+                [Hidden]
+                static void Command3(int x, [Hidden]int y) { Console.Write($"command3: x={x} y={y}"); }
+            """;
+
+        verifier.Execute(code, args: "--help", expected:
+            """
+            Usage: [command] [-h|--help] [--version]
+
+            Commands:
+              command2
+
+            """);
+
+        // Verify commands can be invoked.
+        verifier.Execute(code, args: "command1", expected: "command1");
+        verifier.Execute(code, args: "command2", expected: "command2");
+        verifier.Execute(code, args: "command3 --x 1 --y 2", expected: "command3: x=1 y=2");
+    }
+}


### PR DESCRIPTION
This PR intended to fix #142

**HiddenAttribute's behaviors**
1. When  `[Hidden]` attribute is set on command.  It hide command from **command list**.  
    It can show hidden command help when  explicitly specify hidden command name with `--help` parameter
2. When [Hidden] attribute is set on command parameter. It hide parameter from command help.
    Note: When both `[Argument]`/[Hidden] attribute set. It **silently** ignore `Hidden` attribute.  
    (Because it's positional parameter)
