### PR TITLE
chore: Update dependencies and benchmark relating code

### DIFF
--- a/sandbox/CliFrameworkBenchmark/Benchmark.cs
+++ b/sandbox/CliFrameworkBenchmark/Benchmark.cs
@@ -1,23 +1,15 @@
-// This benchmark project is based on CliFx.Benchmarks.
+﻿// This benchmark project is based on CliFx.Benchmarks.
 // https://github.com/Tyrrrz/CliFx/tree/master/CliFx.Benchmarks/
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Engines;
 using BenchmarkDotNet.Order;
 using CliFx;
 using Cocona.Benchmark.External.Commands;
-using CommandLine;
 using ConsoleAppFramework;
-using PowerArgs;
 using Spectre.Console.Cli;
-using System.ComponentModel.DataAnnotations.Schema;
-using BenchmarkDotNet.Columns;
 
 namespace Cocona.Benchmark.External;
 
-// use ColdStart strategy to measure startup time evaluation
-[SimpleJob(RunStrategy.ColdStart, launchCount: 1, warmupCount: 0, iterationCount: 1, invocationCount: 1)]
-[MemoryDiagnoser]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 public class Benchmark
 {

--- a/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
+++ b/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="CliFx" Version="2.3.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="CliFx" Version="2.3.6" />
     <PackageReference Include="clipr" Version="1.6.1" />
     <PackageReference Include="Cocona" Version="2.2.0" />
     <PackageReference Include="Cocona.Lite" Version="2.2.0" />
@@ -25,9 +25,9 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="PowerArgs" Version="4.0.3" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
+    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta5.25306.1" />
   </ItemGroup>
 
 

--- a/sandbox/CliFrameworkBenchmark/Commands/SystemCommandLineCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/SystemCommandLineCommand.cs
@@ -11,25 +11,37 @@ public class SystemCommandLineCommand
     {
         var command = new RootCommand
         {
-            new Option<string?>(new[] {"--str", "-s"}),
-            new Option<int>(new[] {"--int", "-i"}),
-            new Option<bool>(new[] {"--bool", "-b"}),
+            new Option<string?>("--str", ["-s"]),
+            new Option<int>("--int", ["-i"]),
+            new Option<bool>("--bool", ["-b"]),
         };
 
-        command.Handler = CommandHandler.Create(ExecuteHandler);
-        return command.Invoke(args);
+        command.SetAction(parseResult =>
+        {
+            var handler = CommandHandler.Create(ExecuteHandler);
+            return handler.InvokeAsync(parseResult);
+        });
+
+        ParseResult parseResult = command.Parse(args);
+        return parseResult.Invoke();
     }
 
     public static Task<int> ExecuteAsync(string[] args)
     {
         var command = new RootCommand
         {
-            new Option<string?>(new[] {"--str", "-s"}),
-            new Option<int>(new[] {"--int", "-i"}),
-            new Option<bool>(new[] {"--bool", "-b"}),
+            new Option<string?>("--str", ["-s"]),
+            new Option<int>("--int", ["-i"]),
+            new Option<bool>("--bool", ["-b"]),
         };
 
-        command.Handler = CommandHandler.Create(ExecuteHandler);
-        return command.InvokeAsync(args);
+        command.SetAction((parseResult, cancellationToken) =>
+        {
+            var handler = CommandHandler.Create(ExecuteHandler);
+            return handler.InvokeAsync(parseResult);
+        });
+
+        ParseResult parseResult = command.Parse(args);
+        return parseResult.InvokeAsync();
     }
 }

--- a/sandbox/CliFrameworkBenchmark/Program.cs
+++ b/sandbox/CliFrameworkBenchmark/Program.cs
@@ -21,7 +21,7 @@ class Program
                                   .WithTimeUnit(TimeUnit.Millisecond));
 
         config.AddDiagnoser(MemoryDiagnoser.Default);
-        config.AddDiagnoser(ThreadingDiagnoser.Default);
+        config.AddDiagnoser(new ThreadingDiagnoser(new ThreadingDiagnoserConfig(displayLockContentionWhenZero: false, displayCompletedWorkItemCountWhenZero: false)));
 
         config.AddJob(Job.Default
                          .WithStrategy(RunStrategy.ColdStart)

--- a/sandbox/CliFrameworkBenchmark/Program.cs
+++ b/sandbox/CliFrameworkBenchmark/Program.cs
@@ -2,8 +2,12 @@
 // https://github.com/Tyrrrz/CliFx/tree/master/CliFx.Benchmarks/
 
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.CsProj;
 using Perfolizer.Horology;
 
 namespace Cocona.Benchmark.External;
@@ -12,6 +16,22 @@ class Program
 {
     static void Main(string[] args)
     {
-        BenchmarkRunner.Run<Benchmark>(DefaultConfig.Instance.WithSummaryStyle(SummaryStyle.Default.WithTimeUnit(TimeUnit.Millisecond)), args);
+        var config = DefaultConfig.Instance
+                                  .WithSummaryStyle(SummaryStyle.Default
+                                  .WithTimeUnit(TimeUnit.Millisecond));
+
+        config.AddDiagnoser(MemoryDiagnoser.Default);
+        config.AddDiagnoser(ThreadingDiagnoser.Default);
+
+        config.AddJob(Job.Default
+                         .WithStrategy(RunStrategy.ColdStart)
+                         .WithLaunchCount(1)
+                         .WithWarmupCount(0)
+                         .WithIterationCount(1)
+                         .WithInvocationCount(1)
+                         .WithToolchain(CsProjCoreToolchain.NetCoreApp80)
+                         .DontEnforcePowerPlan());
+
+        BenchmarkRunner.Run<Benchmark>(config, args);
     }
 }

--- a/sandbox/GeneratorSandbox/GeneratorSandbox.csproj
+++ b/sandbox/GeneratorSandbox/GeneratorSandbox.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />-->
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.0" />-->
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
     <!--<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />-->
     <!--<PackageReference Include="ZLogger" Version="2.5.9" />-->
   </ItemGroup>

--- a/src/ConsoleAppFramework/ConsoleAppFramework.csproj
+++ b/src/ConsoleAppFramework/ConsoleAppFramework.csproj
@@ -32,7 +32,7 @@
     <!-- Roslyn for .NET 8 / C# 12 -->
     <!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppFramework.GeneratorTests.csproj
+++ b/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppFramework.GeneratorTests.csproj
@@ -12,10 +12,14 @@
 
   <ItemGroup>
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.v3" Version="1.1.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageReference Include="xunit.v3" Version="2.0.3" />
+  </ItemGroup>
+
+  <!-- Following settings will be removed -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This PR update package dependencies and update benchmark relating code.
to test System.CommandLine `2.0.0-beta5`.

**Before this PR merged**
| Method                   | Mean       | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------------------- |-----------:|----------:|----------:|------:|--------:|----------:|------------:|
| 'ConsoleAppFramework v5' |   1.731 ms | 0.1185 ms | 0.1365 ms |  1.01 |    0.11 |     400 B |        1.00 |
| CliFx                    |  26.083 ms | 0.4402 ms | 0.5069 ms | 15.15 |    1.13 |   62000 B |      155.00 |
| System.CommandLine       |  32.463 ms | 3.0543 ms | 3.5173 ms | 18.86 |    2.42 |   18720 B |       46.80 |
| Cocona.Lite              |  49.657 ms | 1.5002 ms | 1.7277 ms | 28.85 |    2.30 |   60072 B |      150.18 |
| Spectre.Console.Cli      |  60.221 ms | 2.9316 ms | 3.3760 ms | 34.98 |    3.16 |   66016 B |      165.04 |
| Cocona                   | 143.379 ms | 5.7622 ms | 6.6357 ms | 83.29 |    7.08 |  466880 B |    1,167.20 |

**After this PR merged**

| Method                   | Mean       | Error     | StdDev    | Ratio | RatioSD | Completed Work Items | Allocated | Alloc Ratio |
|------------------------- |-----------:|----------:|----------:|------:|--------:|---------------------:|----------:|------------:|
| 'ConsoleAppFramework v5' |   1.737 ms | 0.1390 ms | 0.1601 ms |  1.01 |    0.12 |                    - |         - |          NA |
| System.CommandLine       |  25.508 ms | 1.6135 ms | 1.8581 ms | 14.80 |    1.63 |                    - |   11008 B |          NA |
| CliFx                    |  27.410 ms | 1.9893 ms | 2.2908 ms | 15.90 |    1.87 |                    - |   60712 B |          NA |
| Cocona.Lite              |  52.075 ms | 1.9009 ms | 2.1890 ms | 30.21 |    2.83 |               1.0000 |   59384 B |          NA |
| Spectre.Console.Cli      |  62.090 ms | 2.4840 ms | 2.8606 ms | 36.02 |    3.44 |                    - |   65760 B |          NA |
| Cocona                   | 148.965 ms | 7.1488 ms | 8.2326 ms | 86.43 |    8.65 |               3.0000 |  466128 B |          NA |

Note: `Completed Work Items` columns are displayed. Because `ThreadingDiagnoser` is added..