### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- NuGet Packaging -->
+    <IsPackable>false</IsPackable>
     <PackageVersion>$(Version)</PackageVersion>
     <Authors>Cysharp</Authors>
     <Company>Cysharp</Company>
@@ -15,6 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
   </ItemGroup>
 </Project>

--- a/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
+++ b/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <nullable>annotations</nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 

--- a/sandbox/FilterShareProject/FilterShareProject.csproj
+++ b/sandbox/FilterShareProject/FilterShareProject.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>

--- a/sandbox/GeneratorSandbox/GeneratorSandbox.csproj
+++ b/sandbox/GeneratorSandbox/GeneratorSandbox.csproj
@@ -9,7 +9,6 @@
     <Nullable>disable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>1701;1702;CS8321</NoWarn>
-    <IsPackable>false</IsPackable>
 
     <DefineConstants>USE_EXTERNAL_CONSOLEAPP_ABSTRACTIONS</DefineConstants>
 

--- a/sandbox/NativeAot/NativeAot.csproj
+++ b/sandbox/NativeAot/NativeAot.csproj
@@ -5,14 +5,13 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
 
     <PublishAot>true</PublishAot>
     <IsAotCompatible>true</IsAotCompatible>
     <PublishTrimmed>true</PublishTrimmed>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    
+
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>
 

--- a/src/ConsoleAppFramework.Abstractions/ConsoleAppFramework.Abstractions.csproj
+++ b/src/ConsoleAppFramework.Abstractions/ConsoleAppFramework.Abstractions.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
 
     <!-- NuGet -->
+    <IsPackable>true</IsPackable>
     <PackageId>ConsoleAppFramework.Abstractions</PackageId>
     <Description>ConsoleAppFramework external abstractions library.</Description>
     <Configurations>Debug;Release</Configurations>
@@ -13,7 +14,6 @@
 
   <ItemGroup>
     <None Include="ConsoleAppFramework.Abstractions.props" Pack="true" PackagePath="build" />
-    <None Include="../../Icon.png" Pack="true" PackagePath="/" />
   </ItemGroup>
 
 </Project>

--- a/src/ConsoleAppFramework/ConsoleAppFramework.csproj
+++ b/src/ConsoleAppFramework/ConsoleAppFramework.csproj
@@ -17,6 +17,7 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
 
     <!-- NuGet -->
+    <IsPackable>true</IsPackable>
     <PackageId>ConsoleAppFramework</PackageId>
     <Description>Zero Dependency, Zero Overhead, Zero Reflection, Zero Allocation, AOT Safe CLI Framework powered by C# Source Generator.</Description>
     <Configurations>Debug;Release</Configurations>
@@ -43,8 +44,4 @@
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-  </ItemGroup>
 </Project>
-

--- a/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppFramework.GeneratorTests.csproj
+++ b/tests/ConsoleAppFramework.GeneratorTests/ConsoleAppFramework.GeneratorTests.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <Configurations>Debug;Release</Configurations>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
