### PR TITLE
Clarify relation between "shortName" and parameter aliases to ease migration in ReadMe and RunTest

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1311,7 +1311,7 @@ ConsoleApp.ServiceProvider = scope.ServiceProvider;
 * `app.AddSubCommands<T>` -> `app.Add<T>(string commandPath)`
 * `app.AddAllCommandType` -> `NotSupported`(use `Add<T>` manually)
 * `[Option(int index)]` -> `[Argument]`
-* `[Option(string shortName, string description)]` -> `Xml Document Comment`
+* `[Option(string shortName, string description)]` -> `Xml Document Comment`(use aliases to parameters)
 * `ConsoleAppFilter.Order` -> `NotSupported`(global -> class -> method declarative order)
 * `ConsoleAppOptions.GlobalFilters` -> `app.UseFilter<T>`
 * `ConsoleAppBase` -> inject `ConsoleAppContext`, `CancellationToken` to method

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1311,7 +1311,7 @@ ConsoleApp.ServiceProvider = scope.ServiceProvider;
 * `app.AddSubCommands<T>` -> `app.Add<T>(string commandPath)`
 * `app.AddAllCommandType` -> `NotSupported`(use `Add<T>` manually)
 * `[Option(int index)]` -> `[Argument]`
-* `[Option(string shortName, string description)]` -> `Xml Document Comment`(use aliases to parameters)
+* `[Option(string shortName, string description)]` -> `Xml Document Comment`(Define short names as parameter aliases in the <param> description)
 * `ConsoleAppFilter.Order` -> `NotSupported`(global -> class -> method declarative order)
 * `ConsoleAppOptions.GlobalFilters` -> `app.UseFilter<T>`
 * `ConsoleAppBase` -> inject `ConsoleAppContext`, `CancellationToken` to method

--- a/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/RunTest.cs
@@ -160,4 +160,47 @@ ConsoleApp.Run(args, (string msg = "\\") => Console.Write(msg));
 ConsoleApp.Run(args, (string msg = @"\\") => Console.Write(msg));
 """, "", @"\\");
     }
+
+    [Fact]
+    public void ShortNameAlias()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<FileCommand>();
+app.Run(args);
+
+public class FileCommand
+{
+    /// <summary>Outputs the provided file name.</summary>
+    /// <param name="inputFile">-i, InputFile</param>
+    [Command("")]
+    public void Run(string inputFile) => Console.Write(inputFile);
+}
+""";
+
+        verifier.Execute(code, "--input-file sample.txt", "sample.txt");
+        verifier.Execute(code, "-i sample.txt", "sample.txt");
+    }
+
+    [Fact]
+    public void ShortNameAndLongNameAlias()
+    {
+        var code = """
+var app = ConsoleApp.Create();
+app.Add<FileCommand>();
+app.Run(args);
+
+public class FileCommand
+{
+    /// <summary>Outputs the provided file name.</summary>
+    /// <param name="inputFile">-i|--input, InputFile</param>
+    [Command("")]
+    public void Run(string inputFile) => Console.Write(inputFile);
+}
+""";
+
+        verifier.Execute(code, "--input-file sample.txt", "sample.txt");
+        verifier.Execute(code, "--input sample.txt", "sample.txt");
+        verifier.Execute(code, "-i sample.txt", "sample.txt");
+    }
 }


### PR DESCRIPTION
While v4->v5 migrating, it wasn’t immediately clear that “short names” should be defined as parameter aliases in the <param> XML doc comment.
