### PR TITLE
Add HideDefaultValue attribute

### DIFF
--- a/src/ConsoleAppFramework/Command.cs
+++ b/src/ConsoleAppFramework/Command.cs
@@ -155,6 +155,7 @@ public record class CommandParameter
     public required bool IsNullableReference { get; init; }
     public required bool IsParams { get; init; }
     public required bool IsHidden { get; init; } // Hide command parameter help
+    public bool IsDefaultValueHidden { get; init; } = false; // Hide default value in command parameter help
     public required string Name { get; init; }
     public required string OriginalParameterName { get; init; }
     public required bool HasDefaultValue { get; init; }

--- a/src/ConsoleAppFramework/CommandHelpBuilder.cs
+++ b/src/ConsoleAppFramework/CommandHelpBuilder.cs
@@ -161,7 +161,7 @@ public static class CommandHelpBuilder
         var optionsFormatted = definition.Options
             .Where(x => !x.Index.HasValue)
             .Where(x => !x.IsHidden)
-            .Select(x => (Options: string.Join("|", x.Options) + (x.IsFlag ? string.Empty : $" {x.FormattedValueTypeName}{(x.IsParams ? "..." : "")}"), x.Description, x.IsRequired, x.IsFlag, x.DefaultValue))
+            .Select(x => (Options: string.Join("|", x.Options) + (x.IsFlag ? string.Empty : $" {x.FormattedValueTypeName}{(x.IsParams ? "..." : "")}"), x.Description, x.IsRequired, x.IsFlag, x.DefaultValue, x.IsDefaultValueHidden))
             .ToArray();
 
         if (!optionsFormatted.Any()) return string.Empty;
@@ -202,7 +202,8 @@ public static class CommandHelpBuilder
             }
             else if (opt.DefaultValue != null)
             {
-                sb.Append($" (Default: {opt.DefaultValue})");
+                if (!opt.IsDefaultValueHidden)
+                    sb.Append($" (Default: {opt.DefaultValue})");
             }
             else if (opt.IsRequired)
             {
@@ -285,6 +286,7 @@ public static class CommandHelpBuilder
             var isFlag = item.Type.SpecialType == Microsoft.CodeAnalysis.SpecialType.System_Boolean;
             var isParams = item.IsParams;
             var isHidden = item.IsHidden;
+            var isDefaultValueHidden = item.IsDefaultValueHidden;
 
             var defaultValue = default(string);
             if (item.HasDefaultValue)
@@ -306,7 +308,7 @@ public static class CommandHelpBuilder
             }
 
             var paramTypeName = item.ToTypeShortString();
-            parameterDefinitions.Add(new CommandOptionHelpDefinition(options.Distinct().ToArray(), description, paramTypeName, defaultValue, index, isFlag, isParams, isHidden));
+            parameterDefinitions.Add(new CommandOptionHelpDefinition(options.Distinct().ToArray(), description, paramTypeName, defaultValue, index, isFlag, isParams, isHidden, isDefaultValueHidden));
         }
 
         var commandName = descriptor.Name;
@@ -342,9 +344,10 @@ public static class CommandHelpBuilder
         public bool IsFlag { get; }
         public bool IsParams { get; }
         public bool IsHidden { get; }
+        public bool IsDefaultValueHidden { get; }
         public string FormattedValueTypeName => "<" + ValueTypeName + ">";
 
-        public CommandOptionHelpDefinition(string[] options, string description, string valueTypeName, string? defaultValue, int? index, bool isFlag, bool isParams, bool isHidden)
+        public CommandOptionHelpDefinition(string[] options, string description, string valueTypeName, string? defaultValue, int? index, bool isFlag, bool isParams, bool isHidden, bool isDefaultValueHidden)
         {
             Options = options;
             Description = description;
@@ -354,6 +357,7 @@ public static class CommandHelpBuilder
             IsFlag = isFlag;
             IsParams = isParams;
             IsHidden = isHidden;
+            IsDefaultValueHidden = isDefaultValueHidden;
         }
     }
 }

--- a/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
+++ b/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
@@ -147,6 +147,11 @@ internal sealed class RegisterCommandsAttribute : Attribute
     }
 }
 
+[AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+internal sealed class HideDefaultValueAttribute : Attribute
+{
+}
+
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
 internal class ConsoleAppFrameworkGeneratorOptionsAttribute : Attribute
 {

--- a/src/ConsoleAppFramework/Parser.cs
+++ b/src/ConsoleAppFramework/Parser.cs
@@ -798,6 +798,7 @@ internal class Parser(ConsoleAppFrameworkGeneratorOptions generatorOptions, Diag
                 var isCancellationToken = SymbolEqualityComparer.Default.Equals(x.Type, wellKnownTypes.CancellationToken);
                 var isConsoleAppContext = x.Type!.Name == "ConsoleAppContext";
                 var isHiddenParameter = x.GetAttributes().Any(x => x.AttributeClass?.Name == "HiddenAttribute");
+                var isDefaultValueHidden = x.GetAttributes().Any(x => x.AttributeClass?.Name == "HideDefaultValueAttribute");
 
                 object? keyedServiceKey = null;
                 if (hasFromKeyedServices)
@@ -837,6 +838,7 @@ internal class Parser(ConsoleAppFrameworkGeneratorOptions generatorOptions, Diag
                     IsConsoleAppContext = isConsoleAppContext,
                     IsParams = x.IsParams,
                     IsHidden = isHiddenParameter,
+                    IsDefaultValueHidden = isDefaultValueHidden,
                     Location = x.DeclaringSyntaxReferences[0].GetSyntax().GetLocation(),
                     Type = new EquatableTypeSymbol(x.Type),
                     HasDefaultValue = x.HasExplicitDefaultValue,

--- a/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/HelpTest.cs
@@ -321,6 +321,32 @@ Options:
 """);
     }
 
+    [Fact]
+    public void HideDefaultValue()
+    {
+        var code = """
+ConsoleApp.Run(args, Commands.Hello);
+
+static class Commands
+{
+    /// <summary>
+    /// Display Hello.
+    /// </summary>
+    /// <param name="message">-m, Message to show.</param>
+    public static void Hello([HideDefaultValue]string message = "ConsoleAppFramework") => Console.Write($"Hello, {message}");
+}
+""";
+        verifier.Execute(code, args: "--help", expected: """
+Usage: [options...] [-h|--help] [--version]
+
+Display Hello.
+
+Options:
+  -m|--message <string>    Message to show.
+
+""");
+    }
+
     private static string GetEntryAssemblyVersion()
     {
         var version = Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;


### PR DESCRIPTION
Introduce `[HideDefaultValue]`, which would hide the default value.

Example code:
```cs
ConsoleApp.Run(args, Commands.Hello);

static class Commands
{
    /// <summary>
    /// Display Hello.
    /// </summary>
    /// <param name="message">-m, Message to show.</param>
    public static void Hello([HideDefaultValue]string message = "ConsoleAppFramework") => Console.Write($"Hello, {message}");
}
```

Help output:
```
Usage: [options...] [-h|--help] [--version]

Display Hello.

Options:
  -m|--message <string>    Message to show.
```

Fixes #178