### PR TITLE
chore: Update benchmarks

### DIFF
--- a/sandbox/CliFrameworkBenchmark/Benchmark.cs
+++ b/sandbox/CliFrameworkBenchmark/Benchmark.cs
@@ -40,7 +40,7 @@ public class Benchmark
     [Benchmark(Description = "System.CommandLine")]
     public int ExecuteWithSystemCommandLine()
     {
-        return SystemCommandLineCommand.Execute(Arguments);
+        return new SystemCommandLineCommand().Execute(Arguments);
     }
 
     //[Benchmark(Description = "McMaster.Extensions.CommandLineUtils")]
@@ -71,7 +71,7 @@ public class Benchmark
     [Benchmark(Description = "ConsoleAppFramework v5", Baseline = true)]
     public unsafe void ExecuteConsoleAppFramework()
     {
-        ConsoleApp.Run(Arguments, &ConsoleAppFrameworkCommand.Execute);
+        ConsoleApp.Run(Arguments, &ConsoleAppFrameworkCommandWithCancellationToken.Execute);
     }
 
     // for alpha testing

--- a/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
+++ b/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
     <PackageReference Include="CliFx" Version="2.3.6" />
     <PackageReference Include="clipr" Version="1.6.1" />
     <PackageReference Include="Cocona" Version="2.2.0" />
@@ -25,9 +25,8 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="PowerArgs" Version="4.0.3" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
-    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta5.25306.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.53.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0" />
   </ItemGroup>
 
 

--- a/sandbox/CliFrameworkBenchmark/Commands/SpectreConsoleCliCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/SpectreConsoleCliCommand.cs
@@ -17,7 +17,7 @@ public class SpectreConsoleCliCommand : Command<SpectreConsoleCliCommand.Setting
         public bool boolOption { get; init; }
     }
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/sandbox/CliFrameworkBenchmark/Commands/SystemCommandLineCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/SystemCommandLineCommand.cs
@@ -1,47 +1,26 @@
-﻿using System.CommandLine;
-using System.CommandLine.NamingConventionBinder;
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using System.CommandLine;
 
 namespace Cocona.Benchmark.External.Commands;
 
 public class SystemCommandLineCommand
 {
-    public static int ExecuteHandler(string s, int i, bool b) => 0;
-
-    public static int Execute(string[] args)
+    public int Execute(string[] args)
     {
-        var command = new RootCommand
-        {
-            new Option<string?>("--str", ["-s"]),
-            new Option<int>("--int", ["-i"]),
-            new Option<bool>("--bool", ["-b"]),
-        };
+        var stringOption = new Option<string>("--str", "-s");
+        var intOption = new Option<int>("--int", "-i");
+        var boolOption = new Option<bool>("--bool", "-b");
+
+        var command = new RootCommand { stringOption, intOption, boolOption };
 
         command.SetAction(parseResult =>
         {
-            var handler = CommandHandler.Create(ExecuteHandler);
-            return handler.InvokeAsync(parseResult);
+            _ = parseResult.GetValue(stringOption);
+            _ = parseResult.GetValue(intOption);
+            _ = parseResult.GetValue(boolOption);
         });
 
-        ParseResult parseResult = command.Parse(args);
-        return parseResult.Invoke();
-    }
-
-    public static Task<int> ExecuteAsync(string[] args)
-    {
-        var command = new RootCommand
-        {
-            new Option<string?>("--str", ["-s"]),
-            new Option<int>("--int", ["-i"]),
-            new Option<bool>("--bool", ["-b"]),
-        };
-
-        command.SetAction((parseResult, cancellationToken) =>
-        {
-            var handler = CommandHandler.Create(ExecuteHandler);
-            return handler.InvokeAsync(parseResult);
-        });
-
-        ParseResult parseResult = command.Parse(args);
-        return parseResult.InvokeAsync();
+        return command.Parse(args).Invoke();
     }
 }


### PR DESCRIPTION
This PR update `sandbox/CliFrameworkBenchmark` project.

**What's changed in this PR**
1. Update `System.CommandLine` package to `2.0.0` 
2. Remove deprecated System.CommandLine.NamingConventionBinder package  
   **Note:** CancellationToken parameter is not passed. Because it's supported only when using ExecuteAsync.
3. Update  `Spectre.Console` package to latest version.  
    and add CancellationToken parameter because it's required on latest version.
4. Update ConsoleAppFramework benchmark to use `ConsoleAppFrameworkCommandWithCancellationToken`
5. Update BenchmarkDotNet version.

**Benchmark Results**
| Method                   | Mean       | Error     | StdDev     | Ratio | RatioSD | Completed Work Items | Allocated | Alloc Ratio |
|------------------------- |-----------:|----------:|-----------:|------:|--------:|---------------------:|----------:|------------:|
| 'ConsoleAppFramework v5' |   4.886 ms | 0.3664 ms |  0.4220 ms |  1.01 |    0.12 |               1.0000 |     880 B |        1.00 |
| System.CommandLine       |  15.151 ms | 0.8430 ms |  0.9707 ms |  3.12 |    0.32 |                    - |    7088 B |        8.05 |
| CliFx                    |  26.554 ms | 1.1390 ms |  1.3116 ms |  5.47 |    0.52 |                    - |   66696 B |       75.79 |
| Cocona.Lite              |  49.702 ms | 1.2712 ms |  1.4639 ms | 10.24 |    0.89 |               1.0000 |   59384 B |       67.48 |
| Spectre.Console.Cli      |  61.221 ms | 2.4988 ms |  2.8776 ms | 12.62 |    1.19 |                    - |   69424 B |       78.89 |
| Cocona                   | 149.128 ms | 8.9851 ms | 10.3473 ms | 30.73 |    3.27 |               3.0000 |  476592 B |      541.58 |


 [ReadMe.md](https://github.com/Cysharp/ConsoleAppFramework/blob/master/ReadMe.md) benchmark results image need to be updated.



