### PR TITLE
Match benchmark namespace with project name

### DIFF
--- a/sandbox/CliFrameworkBenchmark/Benchmark.cs
+++ b/sandbox/CliFrameworkBenchmark/Benchmark.cs
@@ -4,11 +4,11 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using CliFx;
-using Cocona.Benchmark.External.Commands;
+using CliFrameworkBenchmarks.Commands;
 using ConsoleAppFramework;
 using Spectre.Console.Cli;
 
-namespace Cocona.Benchmark.External;
+namespace CliFrameworkBenchmarks;
 
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 public class Benchmark

--- a/sandbox/CliFrameworkBenchmark/Commands/CliFxCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/CliFxCommand.cs
@@ -1,9 +1,9 @@
 ﻿using CliFx.Attributes;
 using CliFx.Infrastructure;
 
-namespace Cocona.Benchmark.External.Commands;
+namespace CliFrameworkBenchmarks.Commands;
 
-[CliFx.Attributes.Command]
+[Command]
 public class CliFxCommand : CliFx.ICommand
 {
     [CommandOption("str", 's')]

--- a/sandbox/CliFrameworkBenchmark/Commands/CliprCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/CliprCommand.cs
@@ -1,6 +1,6 @@
 ﻿using clipr;
 
-namespace Cocona.Benchmark.External.Commands;
+namespace CliFrameworkBenchmarks.Commands;
 
 public class CliprCommand
 {

--- a/sandbox/CliFrameworkBenchmark/Commands/CoconaCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/CoconaCommand.cs
@@ -1,13 +1,13 @@
-﻿namespace Cocona.Benchmark.External.Commands;
+﻿namespace CliFrameworkBenchmarks.Commands;
 
 public class CoconaCommand
 {
     public void Execute(
-        [global::Cocona.Option("str", new []{'s'})]
+        [Cocona.Option("str", new []{'s'})]
         string? strOption,
-        [global::Cocona.Option("int", new []{'i'})]
+        [Cocona.Option("int", new []{'i'})]
         int intOption,
-        [global::Cocona.Option("bool", new []{'b'})]
+        [Cocona.Option("bool", new []{'b'})]
         bool boolOption)
     {
     }

--- a/sandbox/CliFrameworkBenchmark/Commands/CommandLineParserCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/CommandLineParserCommand.cs
@@ -1,14 +1,14 @@
-﻿namespace Cocona.Benchmark.External.Commands;
+﻿namespace CliFrameworkBenchmarks.Commands;
 
 public class CommandLineParserCommand
 {
-    [global::CommandLine.Option('s', "str")]
+    [CommandLine.Option('s', "str")]
     public string? StrOption { get; set; }
 
-    [global::CommandLine.Option('i', "int")]
+    [CommandLine.Option('i', "int")]
     public int IntOption { get; set; }
 
-    [global::CommandLine.Option('b', "bool")]
+    [CommandLine.Option('b', "bool")]
     public bool BoolOption { get; set; }
 
     public void Execute()

--- a/sandbox/CliFrameworkBenchmark/Commands/ConsoleAppFrameworkCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/ConsoleAppFrameworkCommand.cs
@@ -1,7 +1,4 @@
-﻿//using ConsoleAppFramework;
-
-//namespace Cocona.Benchmark.External.Commands;
-
+﻿namespace CliFrameworkBenchmarks.Commands;
 //public class ConsoleAppFrameworkCommand : ConsoleAppBase
 //{
 //    public void Execute(
@@ -14,8 +11,6 @@
 //    {
 //    }
 //}
-
-using ConsoleAppFramework;
 
 public class ConsoleAppFrameworkCommand
 {

--- a/sandbox/CliFrameworkBenchmark/Commands/McMasterCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/McMasterCommand.cs
@@ -1,4 +1,4 @@
-﻿namespace Cocona.Benchmark.External.Commands;
+﻿namespace CliFrameworkBenchmarks.Commands;
 
 public class McMasterCommand
 {

--- a/sandbox/CliFrameworkBenchmark/Commands/PowerArgsCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/PowerArgsCommand.cs
@@ -1,6 +1,6 @@
 ﻿using PowerArgs;
 
-namespace Cocona.Benchmark.External.Commands;
+namespace CliFrameworkBenchmarks.Commands;
 
 //public class PowerArgsCommand
 //{

--- a/sandbox/CliFrameworkBenchmark/Commands/SpectreConsoleCliCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/SpectreConsoleCliCommand.cs
@@ -1,7 +1,6 @@
 ﻿using Spectre.Console.Cli;
-using System.ComponentModel;
 
-namespace Cocona.Benchmark.External.Commands;
+namespace CliFrameworkBenchmarks.Commands;
 
 public class SpectreConsoleCliCommand : Command<SpectreConsoleCliCommand.Settings>
 {

--- a/sandbox/CliFrameworkBenchmark/Commands/SystemCommandLineCommand.cs
+++ b/sandbox/CliFrameworkBenchmark/Commands/SystemCommandLineCommand.cs
@@ -1,8 +1,6 @@
-﻿using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
-using System.CommandLine;
+﻿using System.CommandLine;
 
-namespace Cocona.Benchmark.External.Commands;
+namespace CliFrameworkBenchmarks.Commands;
 
 public class SystemCommandLineCommand
 {

--- a/sandbox/CliFrameworkBenchmark/Program.cs
+++ b/sandbox/CliFrameworkBenchmark/Program.cs
@@ -10,7 +10,7 @@ using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Toolchains.CsProj;
 using Perfolizer.Horology;
 
-namespace Cocona.Benchmark.External;
+namespace CliFrameworkBenchmarks;
 
 class Program
 {


### PR DESCRIPTION
The namespace of `CliFrameworkBenchmarks` was set to `Cocona.Benchmark.External` which I assume remained from earlier versions. This PR fixed that.

It doesn't affect anything but the benchmarks project.