### PR TITLE
Invoke WaitAsync directly for Task returning methods

### DIFF
--- a/src/ConsoleAppFramework/Emitter.cs
+++ b/src/ConsoleAppFramework/Emitter.cs
@@ -386,7 +386,14 @@ internal class Emitter(DllReference? dllReference) // from EmitConsoleAppRun, nu
 
                 if (hasCancellationToken)
                 {
-                    invokeCommand = $"Task.Run(() => {invokeCommand}).WaitAsync(posixSignalHandler.TimeoutToken)";
+                    if (command.IsAsync)
+                    {
+                        invokeCommand = $"{invokeCommand}.WaitAsync(posixSignalHandler.TimeoutToken)";
+                    }
+                    else
+                    {
+                        invokeCommand = $"Task.Run(() => {invokeCommand}).WaitAsync(posixSignalHandler.TimeoutToken)";
+                    }
                 }
                 if (command.IsAsync || hasCancellationToken)
                 {


### PR DESCRIPTION
This PR removes an unnecessary `Task.Run` wrapper from `Task` returning methods that accept a `CancellationToken`. The wrapper was redundant because these methods already support `WaitAsync` directly, and it caused unnecessary thread pool overhead.

The `ConsoleAppFramework v5(app with CancellationToken)` benchmark (on my machine), shows 1.7X faster execution and 2.2X less memory allocation.

Before the changes:
<img width="986" height="371" alt="SCR-20251117-qtgq" src="https://github.com/user-attachments/assets/7d18c3aa-7c4e-4d87-aaf9-e35c846abb06" />

After the changes:
<img width="980" height="371" alt="SCR-20251117-qtvx" src="https://github.com/user-attachments/assets/6e19ac5f-3a73-475c-8f17-8cd64b6e97c6" />


