### PR TITLE
Fix enum error message to apply to global options

### DIFF
--- a/src/ConsoleAppFramework/Command.cs
+++ b/src/ConsoleAppFramework/Command.cs
@@ -255,7 +255,7 @@ public record class CommandParameter
                     if (type.TypeKind == TypeKind.Enum)
                     {
                         string typeName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-                        return $"if ({incrementIndex}!Enum.TryParse<{typeName}>(commandArgs[i], true, {outArgVar})) {{ ThrowArgumentParseFailed<{typeName}>(\"{argumentName}\", commandArgs[i]); }}{elseExpr}";
+                        return $"if ({incrementIndex}!Enum.TryParse<{typeName}>(commandArgs[i], true, {outArgVar})) {{ ThrowArgumentParseFailedEnum(typeof({typeName}), \"{argumentName}\", commandArgs[i]); }}{elseExpr}";
                     }
 
                     // ParamsArray

--- a/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
+++ b/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
@@ -257,8 +257,9 @@ internal static partial class ConsoleApp
         throw new ArgumentParseFailedException($"Argument '{argumentName}' failed to parse, provided value: {value}");
     }
 
-    static void ThrowArgumentParseFailed<TEnum>(string argumentName, string value) where TEnum : struct, Enum {
-        var values = string.Join(", ", Enum.GetNames<TEnum>());
+    static void ThrowArgumentParseFailedEnum(Type enumType, string argumentName, string value)
+    {
+        var values = string.Join(", ", Enum.GetNames(enumType));
         throw new ArgumentParseFailedException($"Argument '{argumentName}' is invalid. Provided value: {value}. Valid values: {values}");
     }
 
@@ -745,6 +746,11 @@ internal static partial class ConsoleApp
                     {
                         RemoveRange(ref args, i, 2);
                         return value;
+                    }
+
+                    if (typeof(T).IsEnum)
+                    {
+                        ThrowArgumentParseFailedEnum(typeof(T), args.Span[i], args.Span[i + 1]);
                     }
 
                     ThrowArgumentParseFailed(args.Span[i], args.Span[i + 1]);

--- a/tests/ConsoleAppFramework.GeneratorTests/GlobalOptionTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/GlobalOptionTest.cs
@@ -86,6 +86,32 @@ enum Fruit
     }
 
     [Test]
+    public async Task EnumErrorShowsValidValues()
+    {
+        var result = verifier.Error("""
+ConsoleApp.Log = x => Console.Write(x);
+
+var app = ConsoleApp.Create();
+app.ConfigureGlobalOptions((ref ConsoleApp.GlobalOptionsBuilder builder) =>
+{
+    var fruit = builder.AddGlobalOption("--fruit", "", Fruit.Apple);
+    return fruit;
+});
+
+app.Add("", (ConsoleAppContext context) => { });
+app.Run(args);
+
+enum Fruit
+{
+    Orange, Apple, Grape
+}
+""", "--fruit Potato");
+
+        await Assert.That(result.Stdout).Contains("Argument '--fruit' is invalid. Provided value: Potato. Valid values: Orange, Apple, Grape");
+        await Assert.That(result.ExitCode).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task DefaultValueForOption()
     {
         await verifier.Execute("""


### PR DESCRIPTION
The updates in pull request #222 overlooked global options (sorry about that). This adjusts the `ThrowArgumentParseFailed<T>` method by removing the generic type parameter and having it accept the type directly.

`ParseArgument<T>` in global options would have forced us create the type through reflection in order to use the previous generic version, which is not something we want. This change avoids that.