### PR TITLE
Add ability to repeat arguments to pass array values

### DIFF
--- a/src/ConsoleAppFramework/Command.cs
+++ b/src/ConsoleAppFramework/Command.cs
@@ -273,7 +273,7 @@ public record class CommandParameter
                         {
                             if (elementType.AllInterfaces.Any(x => x.EqualsUnconstructedGenericType(parsable)))
                             {
-                                return $"if ({incrementIndex}!TrySplitParse(commandArgs[i], {outArgVar})) {{ ThrowArgumentParseFailed(\"{argumentName}\", commandArgs[i]); }}{elseExpr}";
+                                return $"if ({incrementIndex}!TrySplitParse(commandArgs[i], arg{argCount})) {{ ThrowArgumentParseFailed(\"{argumentName}\", commandArgs[i]); }}{elseExpr}";
                             }
                         }
                         break;

--- a/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
+++ b/src/ConsoleAppFramework/ConsoleAppBaseCode.cs
@@ -18,6 +18,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Diagnostics.CodeAnalysis;
 using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
 
 """;
 
@@ -37,6 +38,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Diagnostics.CodeAnalysis;
 using System.ComponentModel.DataAnnotations;
+using System.Collections.Generic;
 
 #if !USE_EXTERNAL_CONSOLEAPP_ABSTRACTIONS
 
@@ -296,28 +298,29 @@ internal static partial class ConsoleApp
         return true;
     }
 
-    static bool TrySplitParse<T>(ReadOnlySpan<char> s, out T[] result)
+    static bool TrySplitParse<T>(ReadOnlySpan<char> s, List<T> result)
        where T : ISpanParsable<T>
     {
+        T[] array = default(T[]); 
         if (s.StartsWith("["))
         {
             try
             {
-                result = System.Text.Json.JsonSerializer.Deserialize<T[]>(s, JsonSerializerOptions)!;
+                array = System.Text.Json.JsonSerializer.Deserialize<T[]>(s, JsonSerializerOptions)!;
+                result.AddRange(array);
                 return true;
             }
             catch
             {
-                result = default!;
                 return false;
             }
         }
 
         var count = s.Count(',') + 1;
-        result = new T[count];
+        array = new T[count];
 
         var source = s;
-        var destination = result.AsSpan();
+        var destination = array.AsSpan();
         Span<Range> ranges = stackalloc Range[Math.Min(count, 128)];
 
         while (true)
@@ -348,6 +351,8 @@ internal static partial class ConsoleApp
                 break;
             }
         }
+
+        result.AddRange(array);
 
         return true;
     }

--- a/src/ConsoleAppFramework/Emitter.cs
+++ b/src/ConsoleAppFramework/Emitter.cs
@@ -159,10 +159,18 @@ internal class Emitter(DllReference? dllReference) // from EmitConsoleAppRun, nu
                     var parameter = command.Parameters[i];
                     if (parameter.IsParsable)
                     {
-                        var defaultValue = parameter.IsParams ? $"({parameter.ToTypeDisplayString()})[]"
+                        if (parameter.Type.TypeKind == TypeKind.Array && !parameter.IsParams)
+                        {
+                            sb.AppendLine($"var arg{i} = new List<{((IArrayTypeSymbol)parameter.Type.TypeSymbol).ElementType.ToFullyQualifiedFormatDisplayString()}>();");
+                        }
+                        else
+                        {
+                            var defaultValue = parameter.IsParams ? $"({parameter.ToTypeDisplayString()})[]"
                                          : parameter.HasDefaultValue ? parameter.DefaultValueToString()
                                          : $"default({parameter.Type.ToFullyQualifiedFormatDisplayString()})";
-                        sb.AppendLine($"var arg{i} = {defaultValue};");
+                            sb.AppendLine($"var arg{i} = {defaultValue};");
+                        }
+                        
                         if (parameter.RequireCheckArgumentParsed)
                         {
                             sb.AppendLine($"var arg{i}Parsed = false;");
@@ -348,7 +356,13 @@ internal class Emitter(DllReference? dllReference) // from EmitConsoleAppRun, nu
 
                 // invoke for sync/async, void/int
                 sb.AppendLine();
-                var methodArguments = string.Join(", ", command.Parameters.Select((x, i) => $"arg{i}!"));
+                var methodArguments = string.Join(", ", command.Parameters.Select((x, i) =>
+                {
+                    if (x.IsParsable && x.Type.TypeKind == TypeKind.Array && !x.IsParams)
+                        return $"arg{i}.ToArray()";
+                    else
+                        return $"arg{i}!";
+                }));
                 string invokeCommand;
                 if (command.CommandMethodInfo == null)
                 {

--- a/tests/ConsoleAppFramework.GeneratorTests/ArrayParseTest.cs
+++ b/tests/ConsoleAppFramework.GeneratorTests/ArrayParseTest.cs
@@ -49,6 +49,18 @@ ConsoleApp.Run(args, (int[] ix, string[] sx) =>
     }
 
     [Test]
+    public async Task RepeatArguments()
+    {
+        var code = """
+ConsoleApp.Run(args, (int[] number) =>
+{
+    Console.Write("[" + string.Join(", ", number) + "]");
+});
+""";
+        await verifier.Execute(code, args: "--number 1 --number 2 --number 3 --number 4 --number 5", expected: "[1, 2, 3, 4, 5]");
+    }
+
+    [Test]
     public async Task JsonArray()
     {
         var code = """


### PR DESCRIPTION
#### Code
```cs
ConsoleApp.Run(args, (int[] numbers) =>
{
    foreach (var number in numbers)
        Console.WriteLine(number);
}
```
#### Arguments
```
--numbers 1 --numbers 2 --numbers 3
```
#### Output
```
1
2
3
```