### PR TITLE
Update benchmark dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,3 +16,10 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-patch
+  - package-ecosystem: "nuget"
+    directory: "/sandbox/"
+    schedule: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"

--- a/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
+++ b/sandbox/CliFrameworkBenchmark/CliFrameworkBenchmark.csproj
@@ -15,18 +15,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.6" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageReference Include="CliFx" Version="2.3.6" />
     <PackageReference Include="clipr" Version="1.6.1" />
     <PackageReference Include="Cocona" Version="2.2.0" />
     <PackageReference Include="Cocona.Lite" Version="2.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <!--<PackageReference Include="ConsoleAppFramework" Version="4.2.4" />-->
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageReference Include="PowerArgs" Version="4.0.3" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.53.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.5" />
   </ItemGroup>
 
 


### PR DESCRIPTION
This PR updates ConsoleAppFramework benchmark NuGet dependencies:

- BenchmarkDotNet from 0.15.6 to 0.15.8
- McMaster.Extensions.CommandLine from 4.1.1 to 5.0.1
- Microsoft.Extensions.Hosting from 9.0.0 to 10.0.5
- System.CommandLine from 2.0.0 to 2.0.5
- Spectre.Console.Cli from 0.53.0 to 0.53.1

The PR also adds a section to the dependabot config file to check weekly for updates to NuGet packages in the benchmarks.

Thanks for the making this Cli Framework.